### PR TITLE
Refactor core extension system and add reusable Regex extension base

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -177,31 +177,15 @@ Generation must fail when:
 ### Class-owned custom leaves (`Extension` subtypes)
 
 ```python
-import random
 from abc import ABC, abstractmethod
 
 
 class Regex(Extension, ABC): pass
 
 class RegexABorCD(Regex):
-    def __init__(self, string):
-        self.string = string
-
     @staticmethod
-    def initialize(tree, constraint):
-        return None
-
-    @staticmethod
-    def enumerate_all(tree, constraint, address):  # language: {"ab", "cd"}
-        yield from [RegexABorCD("ab"), RegexABorCD("cd")]
-
-    @staticmethod
-    def arbitrary(tree, constraint, address):
-        return RegexABorCD("ab")
-
-    @staticmethod
-    def uniform_random(tree, constraint, address):
-        return RegexABorCD(random.choice(["ab", "cd"]))
+    def expression() -> str:
+        return "(ab|cd)"
 ```
 
 Then:
@@ -211,4 +195,5 @@ generate(RegexABorCD)
 generate(Annotated[RegexABorCD, Name("R")], methods={"R": "arbitrary"})
 ```
 
-`Regex` is the abstract family, while `RegexABorCD` is one concrete regex language.
+`Regex` is the abstract family and owns the mechanics (`initialize`, `enumerate_all`, `arbitrary`, `uniform_random`).
+`RegexABorCD` is a concrete language that only provides `expression()`.

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -177,23 +177,62 @@ Generation must fail when:
 ### Class-owned custom leaves (`Extension` subtypes)
 
 ```python
-from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Annotated, Iterator
+
+from equivalib.core import (
+    BooleanExpression,
+    Extension,
+    Name,
+    generate,
+)
 
 
-class Regex(Extension, ABC): pass
+@dataclass(frozen=True)
+class Greeting(Extension):
+    text: str
+
+    @staticmethod
+    def initialize(tree: object, constraint: object) -> object:
+        del tree, constraint
+        return None
+
+    @staticmethod
+    def enumerate_all(tree: object, constraint: object, address: str | None) -> Iterator["Greeting"]:
+        del tree, constraint, address
+        return iter((Greeting("hello"), Greeting("hi")))
+
+    @staticmethod
+    def arbitrary(tree: object, constraint: object, address: str | None) -> "Greeting" | None:
+        del tree, constraint, address
+        return Greeting("hello")
+
+    @staticmethod
+    def uniform_random(tree: object, constraint: object, address: str | None) -> "Greeting" | None:
+        del tree, constraint, address
+        return Greeting("hi")
+
+
+assert generate(Greeting, BooleanExpression(True), {}) == {Greeting("hello"), Greeting("hi")}
+assert generate(
+    Annotated[Greeting, Name("G")],
+    BooleanExpression(True),
+    {"G": "arbitrary"},
+) == {Greeting("hello")}
+```
+
+For regex families, `Regex` is the abstract helper base that owns mechanics (`initialize`, `enumerate_all`, `arbitrary`, `uniform_random`), and each concrete subclass provides only `expression()`.
+
+```python
+from equivalib.core import Regex
+
 
 class RegexABorCD(Regex):
     @staticmethod
     def expression() -> str:
         return "(ab|cd)"
-```
 
-Then:
 
-```python
 generate(RegexABorCD)
 generate(Annotated[RegexABorCD, Name("R")], methods={"R": "arbitrary"})
 ```
-
-`Regex` is the abstract family and owns the mechanics (`initialize`, `enumerate_all`, `arbitrary`, `uniform_random`).
-`RegexABorCD` is a concrete language that only provides `expression()`.

--- a/src/equivalib/core/__init__.py
+++ b/src/equivalib/core/__init__.py
@@ -44,10 +44,14 @@ from equivalib.core.expression import (
 from equivalib.core.api import generate
 from equivalib.core.domains import values
 from equivalib.core.cache import mentioned_labels
+from equivalib.core.extension import Extension
+from equivalib.core.regex import Regex
 
 __all__ = [
     "generate",
     "values",
+    "Extension",
+    "Regex",
     "Name",
     "Expression",
     "BooleanExpression",

--- a/src/equivalib/core/api.py
+++ b/src/equivalib/core/api.py
@@ -6,8 +6,9 @@ Public entry point:
 
 from __future__ import annotations
 
-from typing import Iterator, Mapping, Optional, Protocol, Type, TypeVar, cast
+from typing import Mapping, Optional, Type, TypeVar, cast
 
+from equivalib.core.extension import Extension
 from equivalib.core.expression import (
     BooleanExpression,
     Expression,
@@ -53,20 +54,6 @@ from equivalib.core.search import search
 from equivalib.core.methods import apply_methods, Label, Method
 
 GenerateT = TypeVar("GenerateT")
-
-
-class ExtensionHooks(Protocol):
-    @staticmethod
-    def initialize(tree: object, constraint: Expression) -> Optional[Expression]: ...
-
-    @staticmethod
-    def enumerate_all(tree: object, constraint: Expression, address: str | None) -> Iterator[object]: ...
-
-    @staticmethod
-    def arbitrary(tree: object, constraint: Expression, address: str | None) -> object | None: ...
-
-    @staticmethod
-    def uniform_random(tree: object, constraint: Expression, address: str | None) -> object | None: ...
 
 _DEFAULT_CONSTRAINT: Expression = BooleanExpression(True)
 _EXPR_TYPES = (
@@ -216,12 +203,12 @@ def _effective_constraint(node: IRNode, tree: Type[GenerateT], constraint: Expre
     return eff
 
 
-def _extension_classes(node: IRNode) -> set[type[ExtensionHooks]]:
-    classes: set[type[ExtensionHooks]] = set()
+def _extension_classes(node: IRNode) -> set[type[Extension]]:
+    classes: set[type[Extension]] = set()
 
     def walk(n: IRNode) -> None:
         if isinstance(n, ExtensionNode):
-            classes.add(cast(type[ExtensionHooks], n.owner))
+            classes.add(cast(type[Extension], n.owner))
             return
         if isinstance(n, TupleNode):
             for item in n.items:
@@ -246,7 +233,7 @@ def _resolve_extensions(
 ) -> IRNode:
     if isinstance(node, ExtensionNode):
         hook = methods.get(current_label, "all") if current_label is not None else "all"
-        cls = cast(type[ExtensionHooks], node.owner)
+        cls = cast(type[Extension], node.owner)
         if hook == "all":
             values = list(cls.enumerate_all(tree, constraint, address))
         elif hook == "arbitrary":
@@ -255,6 +242,11 @@ def _resolve_extensions(
         else:
             one = cls.uniform_random(tree, constraint, address)
             values = [] if one is None else [one]
+        for value in values:
+            if not isinstance(value, cls):
+                raise TypeError(
+                    f"Extension hook for {cls.__qualname__} returned non-{cls.__qualname__} value: {value!r}."
+                )
         literals = tuple(LiteralNode(v) for v in values)
         if not literals:
             return UnionNode(())

--- a/src/equivalib/core/api.py
+++ b/src/equivalib/core/api.py
@@ -234,6 +234,7 @@ def _resolve_extensions(
     if isinstance(node, ExtensionNode):
         hook = methods.get(current_label, "all") if current_label is not None else "all"
         cls = cast(type[Extension], node.owner)
+        values: list[Extension]
         if hook == "all":
             values = list(cls.enumerate_all(tree, constraint, address))
         elif hook == "arbitrary":

--- a/src/equivalib/core/extension.py
+++ b/src/equivalib/core/extension.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterator, Optional, TypeVar
+
+from equivalib.core.expression import Expression
+
+ExtensionT = TypeVar("ExtensionT", bound="Extension")
+
+
+class Extension(ABC):
+    @staticmethod
+    @abstractmethod
+    def initialize(tree: object, constraint: Expression) -> Optional[Expression]:
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def enumerate_all(
+        tree: object,
+        constraint: Expression,
+        address: str | None,
+    ) -> Iterator[ExtensionT]:
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def arbitrary(
+        tree: object,
+        constraint: Expression,
+        address: str | None,
+    ) -> ExtensionT | None:
+        raise NotImplementedError
+
+    @staticmethod
+    @abstractmethod
+    def uniform_random(
+        tree: object,
+        constraint: Expression,
+        address: str | None,
+    ) -> ExtensionT | None:
+        raise NotImplementedError

--- a/src/equivalib/core/extension.py
+++ b/src/equivalib/core/extension.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Iterator, Optional, TypeVar
+from typing import Iterator, Optional
 
 from equivalib.core.expression import Expression
-
-ExtensionT = TypeVar("ExtensionT", bound="Extension")
-
 
 class Extension(ABC):
     @staticmethod
@@ -20,7 +17,7 @@ class Extension(ABC):
         tree: object,
         constraint: Expression,
         address: str | None,
-    ) -> Iterator[ExtensionT]:
+    ) -> Iterator["Extension"]:
         raise NotImplementedError
 
     @staticmethod
@@ -29,7 +26,7 @@ class Extension(ABC):
         tree: object,
         constraint: Expression,
         address: str | None,
-    ) -> ExtensionT | None:
+    ) -> "Extension" | None:
         raise NotImplementedError
 
     @staticmethod
@@ -38,5 +35,5 @@ class Extension(ABC):
         tree: object,
         constraint: Expression,
         address: str | None,
-    ) -> ExtensionT | None:
+    ) -> "Extension" | None:
         raise NotImplementedError

--- a/src/equivalib/core/normalize.py
+++ b/src/equivalib/core/normalize.py
@@ -10,6 +10,7 @@ import typing
 import types
 import inspect
 
+from equivalib.core.extension import Extension
 from equivalib.core.name import Name
 from equivalib.core.types import (
     NoneNode,
@@ -27,8 +28,7 @@ from equivalib.core.types import (
 def _is_extension_subtype(t: object) -> bool:
     if not inspect.isclass(t):
         return False
-    required = ("initialize", "enumerate_all", "arbitrary", "uniform_random")
-    return any(hasattr(t, name) for name in required)
+    return issubclass(t, Extension)
 
 
 def normalize(t: object) -> IRNode:
@@ -81,7 +81,7 @@ def normalize(t: object) -> IRNode:
 
     if inspect.isclass(t):
         raise ValueError(
-            f"Unsupported class leaf {t!r}: non-base classes must provide Extension hooks."
+            f"Unsupported class leaf {t!r}: non-base classes must be Extension subclasses."
         )
 
     raise ValueError(f"Unsupported type expression: {t!r}")

--- a/src/equivalib/core/regex.py
+++ b/src/equivalib/core/regex.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import random
+import re
+import sre_parse
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from itertools import product
+from typing import Iterator
+
+from equivalib.core.extension import Extension
+from equivalib.core.expression import Expression
+
+_DEFAULT_INFINITE_REPEAT_BOUND = 8
+
+
+@dataclass(frozen=True)
+class Regex(Extension, ABC):
+    value: str
+
+    @staticmethod
+    @abstractmethod
+    def expression() -> str:
+        raise NotImplementedError
+
+    @classmethod
+    def _compiled(cls) -> re.Pattern[str]:
+        return re.compile(cls.expression())
+
+    @classmethod
+    def _parsed(cls) -> sre_parse.SubPattern:
+        return sre_parse.parse(cls.expression())
+
+    @classmethod
+    def _materialize(cls, text: str) -> "Regex":
+        return cls(text)
+
+    @staticmethod
+    def initialize(tree: object, constraint: Expression) -> None:
+        del tree, constraint
+        return None
+
+    @classmethod
+    def enumerate_all(cls, tree: object, constraint: Expression, address: str | None) -> Iterator["Regex"]:
+        del tree, constraint, address
+        for text in _enumerate_subpattern(cls._parsed()):
+            if cls._compiled().fullmatch(text):
+                yield cls._materialize(text)
+
+    @classmethod
+    def arbitrary(cls, tree: object, constraint: Expression, address: str | None) -> "Regex" | None:
+        del tree, constraint, address
+        for text in _enumerate_subpattern(cls._parsed(), infinite_bound=_DEFAULT_INFINITE_REPEAT_BOUND):
+            if cls._compiled().fullmatch(text):
+                return cls._materialize(text)
+        return None
+
+    @classmethod
+    def uniform_random(cls, tree: object, constraint: Expression, address: str | None) -> "Regex" | None:
+        del tree, constraint, address
+        pool = tuple(_enumerate_subpattern(cls._parsed(), infinite_bound=_DEFAULT_INFINITE_REPEAT_BOUND))
+        if not pool:
+            return None
+        return cls._materialize(random.choice(pool))
+
+
+def _enumerate_subpattern(
+    pattern: sre_parse.SubPattern,
+    infinite_bound: int | None = None,
+) -> Iterator[str]:
+    current = [""]
+    for op, arg in pattern.data:
+        pieces = list(_enumerate_token(op, arg, infinite_bound))
+        if not pieces:
+            return
+        current = [prefix + suffix for prefix, suffix in product(current, pieces)]
+    yield from current
+
+
+def _enumerate_token(
+    op: object,
+    arg: object,
+    infinite_bound: int | None,
+) -> Iterator[str]:
+    if op is sre_parse.LITERAL:
+        yield chr(arg)  # type: ignore[arg-type]
+        return
+
+    if op is sre_parse.ANY:
+        for c in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_":
+            yield c
+        return
+
+    if op is sre_parse.IN:
+        for c in _enumerate_in(arg):  # type: ignore[arg-type]
+            yield c
+        return
+
+    if op is sre_parse.BRANCH:
+        _, branches = arg  # type: ignore[misc]
+        for branch in branches:
+            yield from _enumerate_subpattern(branch, infinite_bound)
+        return
+
+    if op is sre_parse.SUBPATTERN:
+        _gid, _add_flags, _del_flags, nested = arg  # type: ignore[misc]
+        yield from _enumerate_subpattern(nested, infinite_bound)
+        return
+
+    if op in (sre_parse.MAX_REPEAT, sre_parse.MIN_REPEAT):
+        lo, hi, nested = arg  # type: ignore[misc]
+        if hi == sre_parse.MAXREPEAT:
+            if infinite_bound is None:
+                raise ValueError("Regex enumerate_all does not support unbounded repeats.")
+            hi = max(lo, infinite_bound)
+        base = tuple(_enumerate_subpattern(nested, infinite_bound))
+        for count in range(lo, hi + 1):
+            if count == 0:
+                yield ""
+                continue
+            for chunk in product(base, repeat=count):
+                yield "".join(chunk)
+        return
+
+    if op is sre_parse.CATEGORY:
+        cat = arg
+        if cat == sre_parse.CATEGORY_DIGIT:
+            yield from "0123456789"
+            return
+        if cat == sre_parse.CATEGORY_SPACE:
+            yield from (" ", "\t")
+            return
+        if cat == sre_parse.CATEGORY_WORD:
+            yield from "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+            return
+        raise ValueError(f"Unsupported regex category: {cat!r}")
+
+    if op is sre_parse.AT:
+        yield ""
+        return
+
+    raise ValueError(f"Unsupported regex op: {op!r}")
+
+
+def _enumerate_in(arg: list[tuple[object, object]]) -> Iterator[str]:
+    negate = False
+    pieces: list[str] = []
+    for in_op, in_arg in arg:
+        if in_op is sre_parse.NEGATE:
+            negate = True
+            continue
+        if in_op is sre_parse.LITERAL:
+            pieces.append(chr(in_arg))
+            continue
+        if in_op is sre_parse.RANGE:
+            lo, hi = in_arg
+            for code in range(lo, hi + 1):
+                pieces.append(chr(code))
+            continue
+        if in_op is sre_parse.CATEGORY:
+            if in_arg == sre_parse.CATEGORY_DIGIT:
+                pieces.extend("0123456789")
+                continue
+            if in_arg == sre_parse.CATEGORY_WORD:
+                pieces.extend("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+                continue
+            raise ValueError(f"Unsupported regex IN category: {in_arg!r}")
+        raise ValueError(f"Unsupported regex IN op: {in_op!r}")
+
+    if not negate:
+        yield from dict.fromkeys(pieces)
+        return
+
+    universe = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+    excluded = set(pieces)
+    for c in universe:
+        if c not in excluded:
+            yield c

--- a/src/equivalib/core/regex.py
+++ b/src/equivalib/core/regex.py
@@ -6,7 +6,7 @@ import sre_parse
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from itertools import product
-from typing import Iterator
+from typing import Any, Iterator, cast
 
 from equivalib.core.extension import Extension
 from equivalib.core.expression import Expression
@@ -38,7 +38,6 @@ class Regex(Extension, ABC):
     @staticmethod
     def initialize(tree: object, constraint: Expression) -> None:
         del tree, constraint
-        return None
 
     @classmethod
     def enumerate_all(cls, tree: object, constraint: Expression, address: str | None) -> Iterator["Regex"]:
@@ -83,7 +82,7 @@ def _enumerate_token(
     infinite_bound: int | None,
 ) -> Iterator[str]:
     if op is sre_parse.LITERAL:
-        yield chr(arg)  # type: ignore[arg-type]
+        yield chr(cast(int, arg))
         return
 
     if op is sre_parse.ANY:
@@ -92,23 +91,23 @@ def _enumerate_token(
         return
 
     if op is sre_parse.IN:
-        for c in _enumerate_in(arg):  # type: ignore[arg-type]
+        for c in _enumerate_in(cast(list[tuple[object, object]], arg)):
             yield c
         return
 
     if op is sre_parse.BRANCH:
-        _, branches = arg  # type: ignore[misc]
+        _, branches = cast(tuple[Any, list[sre_parse.SubPattern]], arg)
         for branch in branches:
             yield from _enumerate_subpattern(branch, infinite_bound)
         return
 
     if op is sre_parse.SUBPATTERN:
-        _gid, _add_flags, _del_flags, nested = arg  # type: ignore[misc]
+        _gid, _add_flags, _del_flags, nested = cast(tuple[Any, Any, Any, sre_parse.SubPattern], arg)
         yield from _enumerate_subpattern(nested, infinite_bound)
         return
 
     if op in (sre_parse.MAX_REPEAT, sre_parse.MIN_REPEAT):
-        lo, hi, nested = arg  # type: ignore[misc]
+        lo, hi, nested = cast(tuple[int, int, sre_parse.SubPattern], arg)
         if hi == sre_parse.MAXREPEAT:
             if infinite_bound is None:
                 raise ValueError("Regex enumerate_all does not support unbounded repeats.")
@@ -150,10 +149,10 @@ def _enumerate_in(arg: list[tuple[object, object]]) -> Iterator[str]:
             negate = True
             continue
         if in_op is sre_parse.LITERAL:
-            pieces.append(chr(in_arg))
+            pieces.append(chr(cast(int, in_arg)))
             continue
         if in_op is sre_parse.RANGE:
-            lo, hi = in_arg
+            lo, hi = cast(tuple[int, int], in_arg)
             for code in range(lo, hi + 1):
                 pieces.append(chr(code))
             continue

--- a/src/equivalib/generic_collapse.py
+++ b/src/equivalib/generic_collapse.py
@@ -2,7 +2,8 @@
 ## This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation; version 3 of the License. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import random
-from typing import Protocol, Union, NoReturn
+from abc import ABC, abstractmethod
+from typing import Union, NoReturn
 
 from equivalib.dynamic import denv
 from equivalib.constant import Constant
@@ -14,10 +15,14 @@ from equivalib.structure import Structure, VarName
 import equivalib.labelled_type as LT
 
 
-class Collapser(Protocol):
+class Collapser(ABC):
     # pylint: disable=multiple-statements
-    def __init__(self, ctx: Sentence) -> None: pass
-    def collapse(self, var: Comparable) -> Union[VarName, Constant]: pass
+    def __init__(self, ctx: Sentence) -> None:
+        del ctx
+
+    @abstractmethod
+    def collapse(self, var: Comparable) -> Union[VarName, Constant]:
+        raise NotImplementedError
 
 
 def generic_collapse(self: Sentence, coll_t: type[Collapser]) -> Sentence:

--- a/tests/test_core_extensions.py
+++ b/tests/test_core_extensions.py
@@ -2,17 +2,13 @@ from __future__ import annotations
 
 import importlib
 import inspect
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Annotated, Any, Iterator, Optional, Type, TypeVar, cast
+from typing import Annotated, Any, Iterator, cast
 
 import pytest
 
 from equivalib.core.expression import And, Eq, Expression, Ge, Le
 from equivalib.core.name import Name as CoreName
-
-
-T = TypeVar("T")
 
 def core_attr(name: str) -> Any:
     module = importlib.import_module("equivalib.core")
@@ -53,62 +49,47 @@ class NotExtensionLeaf:
     token: str = "x"
 
 
-class Extension(ABC):
-    @staticmethod
-    @abstractmethod
-    def initialize(tree: Type[T], constraint: Expression) -> Optional[Expression]:
-        raise NotImplementedError
-
-    @staticmethod
-    @abstractmethod
-    def enumerate_all(tree: Type[T], constraint: Expression, address: Optional[str]) -> Iterator[object]:
-        raise NotImplementedError
-
-    @staticmethod
-    @abstractmethod
-    def arbitrary(tree: Type[T], constraint: Expression, address: Optional[str]) -> Optional[object]:
-        raise NotImplementedError
-
-    @staticmethod
-    @abstractmethod
-    def uniform_random(tree: Type[T], constraint: Expression, address: Optional[str]) -> Optional[object]:
-        raise NotImplementedError
+Extension = core_attr("Extension")
+Regex = core_attr("Regex")
 
 
+@dataclass(frozen=True)
 class Palette(Extension):
+    token: str
+
     @staticmethod
-    def initialize(tree: Type[T], constraint: Expression) -> Optional[Expression]:
+    def initialize(tree: object, constraint: Expression) -> Expression | None:
         return None
 
     @staticmethod
-    def enumerate_all(tree: Type[T], constraint: Expression, address: Optional[str]) -> Iterator[object]:
+    def enumerate_all(tree: object, constraint: Expression, address: str | None) -> Iterator["Palette"]:
         del tree, constraint, address
-        return iter(("red", "orange"))
+        return iter((Palette("red"), Palette("orange")))
 
     @staticmethod
-    def arbitrary(tree: Type[T], constraint: Expression, address: Optional[str]) -> Optional[object]:
+    def arbitrary(tree: object, constraint: Expression, address: str | None) -> "Palette" | None:
         del tree, constraint, address
-        return "red"
+        return Palette("red")
 
     @staticmethod
-    def uniform_random(tree: Type[T], constraint: Expression, address: Optional[str]) -> Optional[object]:
+    def uniform_random(tree: object, constraint: Expression, address: str | None) -> "Palette" | None:
         del tree, constraint, address
-        return "orange"
+        return Palette("orange")
 
 
 class InvalidInitialize(Extension):
     @staticmethod
-    def enumerate_all(tree: Type[T], constraint: Expression, address: Optional[str]) -> Iterator[object]:
+    def enumerate_all(tree: object, constraint: Expression, address: str | None) -> Iterator["InvalidInitialize"]:
         del tree, constraint, address
         return iter(())
 
     @staticmethod
-    def arbitrary(tree: Type[T], constraint: Expression, address: Optional[str]) -> Optional[object]:
+    def arbitrary(tree: object, constraint: Expression, address: str | None) -> "InvalidInitialize" | None:
         del tree, constraint, address
         return None
 
     @staticmethod
-    def uniform_random(tree: Type[T], constraint: Expression, address: Optional[str]) -> Optional[object]:
+    def uniform_random(tree: object, constraint: Expression, address: str | None) -> "InvalidInitialize" | None:
         del tree, constraint, address
         return None
 
@@ -142,7 +123,7 @@ def test_class_missing_required_initialize_method_is_rejected():
 
 
 def test_extension_subclass_can_drive_exhaustive_generation():
-    assert generate_core(Palette) == {"red", "orange"}
+    assert generate_core(Palette) == {Palette("red"), Palette("orange")}
 
 
 # ---------------------------------------------------------------------------
@@ -152,30 +133,30 @@ def test_extension_subclass_can_drive_exhaustive_generation():
 
 class BoundedByInitialize(Extension):
     @staticmethod
-    def initialize(tree: Type[T], constraint: Expression) -> Optional[Expression]:
+    def initialize(tree: object, constraint: Expression) -> Expression | None:
         del tree, constraint
         return cast(Expression, _int_bounds("X", 1, 2))
 
     @staticmethod
-    def enumerate_all(tree: Type[T], constraint: Expression, address: Optional[str]) -> Iterator[object]:
+    def enumerate_all(tree: object, constraint: Expression, address: str | None) -> Iterator["BoundedByInitialize"]:
         del tree, constraint, address
-        return iter(("ok",))
+        return iter((BoundedByInitialize(),))
 
     @staticmethod
-    def arbitrary(tree: Type[T], constraint: Expression, address: Optional[str]) -> Optional[object]:
+    def arbitrary(tree: object, constraint: Expression, address: str | None) -> "BoundedByInitialize" | None:
         del tree, constraint, address
-        return "ok"
+        return BoundedByInitialize()
 
     @staticmethod
-    def uniform_random(tree: Type[T], constraint: Expression, address: Optional[str]) -> Optional[object]:
+    def uniform_random(tree: object, constraint: Expression, address: str | None) -> "BoundedByInitialize" | None:
         del tree, constraint, address
-        return "ok"
+        return BoundedByInitialize()
 
 
 def test_initialize_constraint_is_anded_into_effective_constraint():
     tree = tuple[Annotated[int, CoreName("X")], BoundedByInitialize]
     result = generate_core(tree, _int_bounds("X", 0, 3))
-    assert result == {(1, "ok"), (2, "ok")}
+    assert result == {(1, BoundedByInitialize()), (2, BoundedByInitialize())}
 
 
 # ---------------------------------------------------------------------------
@@ -185,17 +166,17 @@ def test_initialize_constraint_is_anded_into_effective_constraint():
 
 def test_named_custom_class_all_uses_enumerate_all():
     tree = Annotated[Palette, CoreName("P")]
-    assert generate_core(tree) == {"red", "orange"}
+    assert generate_core(tree) == {Palette("red"), Palette("orange")}
 
 
 def test_named_custom_class_arbitrary_uses_arbitrary_hook():
     tree = Annotated[Palette, CoreName("P")]
-    assert generate_core(tree, methods={"P": "arbitrary"}) == {"red"}
+    assert generate_core(tree, methods={"P": "arbitrary"}) == {Palette("red")}
 
 
 def test_named_custom_class_uniform_random_uses_uniform_random_hook():
     tree = Annotated[Palette, CoreName("P")]
-    assert generate_core(tree, methods={"P": "uniform_random"}) == {"orange"}
+    assert generate_core(tree, methods={"P": "uniform_random"}) == {Palette("orange")}
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +187,7 @@ def test_named_custom_class_uniform_random_uses_uniform_random_hook():
 def test_custom_class_address_from_name_and_tuple_path():
     tree = tuple[Annotated[Palette, CoreName("P")], Annotated[Palette, CoreName("Q")]]
     all_results = generate_core(tree)
-    assert ("red", "red") in all_results
+    assert (Palette("red"), Palette("red")) in all_results
 
 
 def test_custom_class_leaf_remains_atomic_for_subpaths():
@@ -227,3 +208,46 @@ def test_bool_behavior_still_uses_core_semantics():
 def test_int_behavior_still_uses_core_semantics():
     tree = Annotated[int, CoreName("X")]
     assert generate_core(tree, _int_bounds("X", 1, 2)) == {1, 2}
+
+
+class BadPalette(Palette):
+    @staticmethod
+    def arbitrary(tree: object, constraint: Expression, address: str | None) -> Palette | None:
+        del tree, constraint, address
+        return Palette("red")
+
+
+def test_arbitrary_must_return_concrete_subclass_instance():
+    tree = Annotated[BadPalette, CoreName("P")]
+    with pytest.raises(TypeError, match="non-BadPalette"):
+        generate_core(tree, methods={"P": "arbitrary"})
+
+
+class RegexABorCD(Regex):
+    @staticmethod
+    def expression() -> str:
+        return "(ab|cd)"
+
+
+class RegexDigits3(Regex):
+    @staticmethod
+    def expression() -> str:
+        return r"\\d{3}"
+
+
+def test_regex_extension_enumerates_concrete_language():
+    assert generate_core(RegexABorCD) == {RegexABorCD("ab"), RegexABorCD("cd")}
+
+
+def test_regex_extension_arbitrary_and_uniform_random_return_subclass():
+    arb = generate_core(Annotated[RegexABorCD, CoreName("R")], methods={"R": "arbitrary"})
+    rand = generate_core(Annotated[RegexABorCD, CoreName("R")], methods={"R": "uniform_random"})
+    assert arb <= {RegexABorCD("ab"), RegexABorCD("cd")}
+    assert rand <= {RegexABorCD("ab"), RegexABorCD("cd")}
+
+
+def test_regex_extension_handles_repetition_and_ranges():
+    values = generate_core(RegexDigits3)
+    assert len(values) == 1000
+    assert RegexDigits3("000") in values
+    assert RegexDigits3("999") in values

--- a/tests/test_core_extensions.py
+++ b/tests/test_core_extensions.py
@@ -7,6 +7,7 @@ from typing import Annotated, Any, Iterator, cast
 
 import pytest
 
+from equivalib.core import Extension, Regex
 from equivalib.core.expression import And, Eq, Expression, Ge, Le
 from equivalib.core.name import Name as CoreName
 
@@ -47,10 +48,6 @@ def generate_core(
 @dataclass(frozen=True)
 class NotExtensionLeaf:
     token: str = "x"
-
-
-Extension = core_attr("Extension")
-Regex = core_attr("Regex")
 
 
 @dataclass(frozen=True)
@@ -131,6 +128,7 @@ def test_extension_subclass_can_drive_exhaustive_generation():
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
 class BoundedByInitialize(Extension):
     @staticmethod
     def initialize(tree: object, constraint: Expression) -> Expression | None:
@@ -232,7 +230,7 @@ class RegexABorCD(Regex):
 class RegexDigits3(Regex):
     @staticmethod
     def expression() -> str:
-        return r"\\d{3}"
+        return r"\d{3}"
 
 
 def test_regex_extension_enumerates_concrete_language():


### PR DESCRIPTION
### Motivation
- Make core extension behavior driven by real subclassing rather than ad-hoc `Protocol` checks so extension ownership and typing are unambiguous. 
- Ensure extension hooks return values of the concrete extension subclass so the core can safely convert hook outputs into literal IR nodes. 
- Provide a reusable `Regex` extension that implements the mechanical enumeration/random/arbitrary logic so concrete regex families only supply a concrete expression.

### Description
- Introduced `Extension` ABC with explicit hook signatures in `src/equivalib/core/extension.py` and switched extension discovery to strict `issubclass(..., Extension)` in `src/equivalib/core/normalize.py`. 
- Tightened runtime validation in `src/equivalib/core/api.py` to assert that values returned by `enumerate_all`/`arbitrary`/`uniform_random` are instances of the resolved concrete extension subclass. 
- Added a reusable `Regex` base in `src/equivalib/core/regex.py` that requires subclasses to implement `@staticmethod expression() -> str` and implements `initialize`, `enumerate_all`, `arbitrary`, and `uniform_random` using regex parsing/enumeration helpers. 
- Updated public core exports to include `Extension` and `Regex`, replaced a `Protocol` with an ABC for `Collapser`, updated docs (`docs/extensions.md`), and expanded `tests/test_core_extensions.py` to assert concrete-instance semantics and exercise the `Regex` extension.

### Testing
- Ran `python -m compileall src tests` which completed successfully. 
- Attempted `pytest -q tests/test_core_extensions.py` but collection failed due to missing external dependency `ortools` in the environment (import error), so the full pytest run could not complete. 
- Attempted dependency sync (`uv sync --all-extras`) but package fetch failed due to a network/tunnel error, preventing full test execution in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf940b4bc832ebf262e4da3f4cf6b)