### PR TITLE
Switch extension tuple addresses to bracket notation

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -113,7 +113,7 @@ All later validation/search/method dispatch and extension hook calls use `constr
 `address` identifies the owned occurrence:
 
 - Named occurrence `Annotated[..., Name("X")]` → `"X"`
-- Reachable tuple child from addressable parent → dot path (e.g. `"X.0"`, `"0.1"`)
+- Reachable tuple child from addressable parent → bracket path (e.g. `"X[0]"`, `"X[1][2]"`, `"0[1]"`)
 - Otherwise `None`
 
 Repeated identical labels denote the same logical variable.

--- a/src/equivalib/core/api.py
+++ b/src/equivalib/core/api.py
@@ -257,7 +257,7 @@ def _resolve_extensions(
     if isinstance(node, TupleNode):
         items: list[IRNode] = []
         for idx, item in enumerate(node.items):
-            child_address = f"{address}.{idx}" if address is not None else str(idx)
+            child_address = f"{address}[{idx}]" if address is not None else str(idx)
             items.append(_resolve_extensions(item, tree, constraint, methods, child_address, current_label))
         return TupleNode(tuple(items))
     if isinstance(node, UnionNode):

--- a/tests/test_core_extensions.py
+++ b/tests/test_core_extensions.py
@@ -284,8 +284,8 @@ def test_extension_address_uses_bracket_notation_from_named_tuple_path():
     AddressEcho.seen_addresses.clear()
     tree = Annotated[tuple[bool, tuple[AddressEcho]], CoreName("X")]
     result = generate_core(tree, methods={"X": "arbitrary"})
-    assert result == {(False, (AddressEcho("ok"),)), (True, (AddressEcho("ok"),))}
-    assert AddressEcho.seen_addresses == ["X[1][0]", "X[1][0]"]
+    assert result == {(False, (AddressEcho("ok"),))}
+    assert AddressEcho.seen_addresses == ["X[1][0]"]
 
 
 def test_extension_address_uses_bracket_notation_from_unnamed_tuple_path():

--- a/tests/test_core_extensions.py
+++ b/tests/test_core_extensions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 import inspect
 from dataclasses import dataclass
-from typing import Annotated, Any, Iterator, cast
+from typing import Annotated, Any, ClassVar, Iterator, cast
 
 import pytest
 
@@ -249,3 +249,48 @@ def test_regex_extension_handles_repetition_and_ranges():
     assert len(values) == 1000
     assert RegexDigits3("000") in values
     assert RegexDigits3("999") in values
+
+
+@dataclass(frozen=True)
+class AddressEcho(Extension):
+    token: str
+    seen_addresses: ClassVar[list[str | None]] = []
+
+    @staticmethod
+    def initialize(tree: object, constraint: Expression) -> Expression | None:
+        del tree, constraint
+        return None
+
+    @staticmethod
+    def enumerate_all(tree: object, constraint: Expression, address: str | None) -> Iterator["AddressEcho"]:
+        del tree, constraint
+        AddressEcho.seen_addresses.append(address)
+        return iter((AddressEcho("ok"),))
+
+    @staticmethod
+    def arbitrary(tree: object, constraint: Expression, address: str | None) -> "AddressEcho" | None:
+        del tree, constraint
+        AddressEcho.seen_addresses.append(address)
+        return AddressEcho("ok")
+
+    @staticmethod
+    def uniform_random(tree: object, constraint: Expression, address: str | None) -> "AddressEcho" | None:
+        del tree, constraint
+        AddressEcho.seen_addresses.append(address)
+        return AddressEcho("ok")
+
+
+def test_extension_address_uses_bracket_notation_from_named_tuple_path():
+    AddressEcho.seen_addresses.clear()
+    tree = Annotated[tuple[bool, tuple[AddressEcho]], CoreName("X")]
+    result = generate_core(tree, methods={"X": "arbitrary"})
+    assert result == {(False, (AddressEcho("ok"),)), (True, (AddressEcho("ok"),))}
+    assert AddressEcho.seen_addresses == ["X[1][0]", "X[1][0]"]
+
+
+def test_extension_address_uses_bracket_notation_from_unnamed_tuple_path():
+    AddressEcho.seen_addresses.clear()
+    tree = tuple[bool, tuple[AddressEcho]]
+    result = generate_core(tree)
+    assert result == {(False, (AddressEcho("ok"),)), (True, (AddressEcho("ok"),))}
+    assert AddressEcho.seen_addresses == ["1[0]"]


### PR DESCRIPTION
### Motivation
- The project must use bracket-style tuple addressing for extension hook `address` values (e.g. `X[1][2][3]`) instead of dotted numeric paths to avoid ambiguous or invalid dotted identifiers.

### Description
- Change the extension address construction in `_resolve_extensions` to build child addresses with bracket notation by replacing `f"{address}.{idx}"` with `f"{address}[{idx}]"` in `src/equivalib/core/api.py`.
- Update the extension specification in `docs/extensions.md` to document bracket-form tuple paths (examples: `"X[0]"`, `"X[1][2]"`, `"0[1]"`).
- Add tests in `tests/test_core_extensions.py` (including a small `AddressEcho` extension) that capture and assert the `address` parameter received by extension hooks for both named and unnamed tuple roots, and add the required `ClassVar` import.

### Testing
- Ran `python -m compileall src/equivalib/core/api.py tests/test_core_extensions.py` which succeeded and shows the modified files compile.
- Ran `uv run pytest -q tests/test_core_extensions.py` which failed during test collection due to a missing `ortools` dependency in the execution environment, so the new tests could not be executed end-to-end here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec438780b0832ebd4366d8391b479e)