### PR TITLE
Use strict 0-based tuple addressing in core

### DIFF
--- a/docs/spec1.md
+++ b/docs/spec1.md
@@ -262,7 +262,7 @@ Where:
 
 - `value` is a boolean or integer constant
 - `label` is a `Label`
-- `path` is a finite tuple of zero-based tuple indices
+- `path` is a finite tuple of zero-based tuple indices (`0` = first element, `1` = second, etc.)
 
 Examples:
 
@@ -296,6 +296,7 @@ Or(
 Address evaluation MUST fail if any step:
 
 - indexes a non-tuple value, or
+- uses a negative index, or
 - uses an out-of-range index
 
 ### Mentioned labels

--- a/src/equivalib/core/eval.py
+++ b/src/equivalib/core/eval.py
@@ -60,6 +60,28 @@ Unknown = _UnknownType()
 
 
 # ---------------------------------------------------------------------------
+# Tuple path addressing helper
+# ---------------------------------------------------------------------------
+
+def _follow_reference_path(value: object, path: tuple[int, ...], label: str) -> object:
+    """Follow ``path`` into ``value`` using strict zero-based tuple indexing."""
+    current = value
+    for depth, idx in enumerate(path):
+        if not isinstance(current, tuple):
+            raise TypeError(
+                f"Reference {label!r} path {path!r} descends into non-tuple "
+                f"at depth {depth}: {current!r}."
+            )
+        if idx < 0 or idx >= len(current):
+            raise IndexError(
+                f"Reference {label!r} path {path!r} uses out-of-range zero-based "
+                f"index {idx} at depth {depth} for tuple length {len(current)}."
+            )
+        current = current[idx]
+    return current
+
+
+# ---------------------------------------------------------------------------
 # Structural equality helper
 # ---------------------------------------------------------------------------
 
@@ -100,9 +122,7 @@ def _eval(expr: Expression, assignment: dict[str, object]) -> object:
         return expr.value
     if isinstance(expr, Reference):
         value: object = assignment[expr.label]
-        for idx in expr.path:
-            value = value[idx]  # type: ignore[index]
-        return value
+        return _follow_reference_path(value, expr.path, expr.label)
     if isinstance(expr, Neg):
         return -_eval(expr.operand, assignment)  # type: ignore[operator]
     if isinstance(expr, Add):
@@ -156,10 +176,23 @@ def _eval_partial(expr: Expression, pa: dict[str, object]) -> object:
         if expr.label not in pa:
             return Unknown
         value: object = pa[expr.label]
-        for idx in expr.path:
+        for prefix_len in range(len(expr.path) + 1):
             if isinstance(value, _UnknownType):
                 return Unknown
-            value = value[idx]  # type: ignore[index]
+            if prefix_len == len(expr.path):
+                return value
+            idx = expr.path[prefix_len]
+            if not isinstance(value, tuple):
+                raise TypeError(
+                    f"Reference {expr.label!r} path {expr.path!r} descends into non-tuple "
+                    f"at depth {prefix_len}: {value!r}."
+                )
+            if idx < 0 or idx >= len(value):
+                raise IndexError(
+                    f"Reference {expr.label!r} path {expr.path!r} uses out-of-range zero-based "
+                    f"index {idx} at depth {prefix_len} for tuple length {len(value)}."
+                )
+            value = value[idx]
         return value
     if isinstance(expr, Neg):
         v = _eval_partial(expr.operand, pa)

--- a/src/equivalib/core/sat.py
+++ b/src/equivalib/core/sat.py
@@ -73,6 +73,28 @@ _EncResult = tuple[Any, str, bool, Literal[True] | cp_model.IntVar]
 
 
 # ---------------------------------------------------------------------------
+# Tuple path addressing helper
+# ---------------------------------------------------------------------------
+
+def _follow_reference_path(value: object, path: tuple[int, ...], label: str) -> object:
+    """Follow ``path`` into ``value`` using strict zero-based tuple indexing."""
+    current = value
+    for depth, idx in enumerate(path):
+        if not isinstance(current, tuple):
+            raise TypeError(
+                f"Reference {label!r} path {path!r} descends into non-tuple "
+                f"at depth {depth}: {current!r}."
+            )
+        if idx < 0 or idx >= len(current):
+            raise IndexError(
+                f"Reference {label!r} path {path!r} uses out-of-range zero-based "
+                f"index {idx} at depth {depth} for tuple length {len(current)}."
+            )
+        current = current[idx]
+    return current
+
+
+# ---------------------------------------------------------------------------
 # Domain computation helpers
 # ---------------------------------------------------------------------------
 
@@ -567,9 +589,7 @@ def _add_constraint(
             model.add_bool_and([sat_vars[label]])
             return
         if label in enum_assignment:
-            v: object = enum_assignment[label]
-            for idx in expr.path:
-                v = v[idx]  # type: ignore[index]
+            v = _follow_reference_path(enum_assignment[label], expr.path, label)
             if v is False:
                 model.add_bool_or([])  # constraint is False → unsatisfiable
             # v is True → no constraint needed
@@ -628,9 +648,7 @@ def _reify_constraint(
             # Reify the boolean SAT variable directly.
             model.add(sat_vars[label] == b)
         elif label in enum_assignment:
-            v: object = enum_assignment[label]
-            for idx in expr.path:
-                v = v[idx]  # type: ignore[index]
+            v = _follow_reference_path(enum_assignment[label], expr.path, label)
             if v is True:
                 model.add_bool_and([b])
             else:
@@ -723,9 +741,7 @@ def _encode_arith(
             return (sat_vars[label], sat_kinds[label], False, True)
         if label in enum_assignment:
             # Navigate the path in the Python value.
-            v: object = enum_assignment[label]
-            for idx in expr.path:
-                v = v[idx]  # type: ignore[index]
+            v = _follow_reference_path(enum_assignment[label], expr.path, label)
             if isinstance(v, bool):
                 return (int(v), _BOOL, True, True)
             if isinstance(v, int):
@@ -1004,9 +1020,7 @@ def _compute_bounds(
         if label in sat_bounds:
             return sat_bounds[label]
         if label in enum_assignment:
-            v2: object = enum_assignment[label]
-            for idx in expr.path:
-                v2 = v2[idx]  # type: ignore[index]
+            v2 = _follow_reference_path(enum_assignment[label], expr.path, label)
             if isinstance(v2, int):  # includes bool
                 iv = int(v2)
                 return (iv, iv)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -738,6 +738,16 @@ def test_generate_rejects_address_out_of_range_on_all_union_branches():
         generate(tree, Eq(ref("X", (1,)), bool_const(True)), {})
 
 
+def test_generate_rejects_negative_tuple_index():
+    """Tuple paths are strictly zero-based; negative indices are invalid."""
+    generate = core_attr("generate")
+    Name = core_attr("Name")
+    Eq = core_attr("Eq")
+    tree = Annotated[Tuple[bool, bool], Name("X")]
+    with pytest.raises(ValueError, match="out of range"):
+        generate(tree, Eq(ref("X", (-1,)), bool_const(True)), {})
+
+
 def test_generate_rejects_address_valid_only_in_first_union_branch():
     """A path must be valid in every union branch, not just the first."""
     generate = core_attr("generate")
@@ -2329,6 +2339,13 @@ def test_reference_path_into_enum_tuple_as_hard_constraint():
     constraint = Reference("T", (1,))
     assignments = _sat_search(node, constraint)
     assert assignments == [], f"Expected no solutions, got {assignments}"
+
+
+def test_eval_reference_path_uses_zero_based_tuple_indices():
+    expr = Reference("T", (0,))
+    assert eval_expression(expr, {"T": (11, 22)}) == 11
+    expr_second = Reference("T", (1,))
+    assert eval_expression(expr_second, {"T": (11, 22)}) == 22
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Make tuple addressing semantics explicit and consistent: tuple path indices are strictly zero-based (`0` = first element). 
- Prevent reliance on Python's permissive indexing behavior (e.g. negative indices) by failing fast on invalid addresses. 
- Ensure spec, implementation, and tests agree on the addressing convention.

### Description
- Added a shared helper ` _follow_reference_path(value, path, label)` and used it in `src/equivalib/core/eval.py` and `src/equivalib/core/sat.py` to traverse tuple paths with strict zero-based indexing and explicit error messages for non-tuple descent and invalid indices. 
- Replaced ad-hoc `for idx in expr.path` tuple traversal with the helper in evaluation, partial-evaluation, SAT encoding, reification, and bounds computation. 
- Updated the specification in `docs/spec1.md` to state that `path` is zero-based and to explicitly call out negative-index rejection. 
- Added tests in `tests/test_core.py` to assert rejection of negative indices (`test_generate_rejects_negative_tuple_index`) and to verify that `Reference(..., (0,))`/`(1,)` resolve to the first/second tuple elements (`test_eval_reference_path_uses_zero_based_tuple_indices`).

### Testing
- Ran `uv run ruff check src/equivalib/core/eval.py src/equivalib/core/sat.py tests/test_core.py`, which passed. 
- Ran `python -m compileall` on the modified files, which succeeded. 
- Attempted `pytest -q` for the targeted tests, but test execution in this environment failed due to a missing `ortools` dependency, so full pytest results are unavailable here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4c3edc10832eb1b654211fa80dcf)