### PR TITLE
Use bracketed root tuple addresses for extension resolution

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -113,7 +113,7 @@ All later validation/search/method dispatch and extension hook calls use `constr
 `address` identifies the owned occurrence:
 
 - Named occurrence `Annotated[..., Name("X")]` → `"X"`
-- Reachable tuple child from addressable parent → bracket path (e.g. `"X[0]"`, `"X[1][2]"`, `"0[1]"`)
+- Reachable tuple child from addressable parent → bracket path (e.g. `"X[0]"`, `"X[1][2]"`, `"[0][1]"`)
 - Otherwise `None`
 
 Repeated identical labels denote the same logical variable.

--- a/src/equivalib/core/api.py
+++ b/src/equivalib/core/api.py
@@ -257,7 +257,7 @@ def _resolve_extensions(
     if isinstance(node, TupleNode):
         items: list[IRNode] = []
         for idx, item in enumerate(node.items):
-            child_address = f"{address}[{idx}]" if address is not None else str(idx)
+            child_address = f"{address}[{idx}]" if address is not None else f"[{idx}]"
             items.append(_resolve_extensions(item, tree, constraint, methods, child_address, current_label))
         return TupleNode(tuple(items))
     if isinstance(node, UnionNode):

--- a/tests/test_core_extensions.py
+++ b/tests/test_core_extensions.py
@@ -293,4 +293,4 @@ def test_extension_address_uses_bracket_notation_from_unnamed_tuple_path():
     tree = tuple[bool, tuple[AddressEcho]]
     result = generate_core(tree)
     assert result == {(False, (AddressEcho("ok"),)), (True, (AddressEcho("ok"),))}
-    assert AddressEcho.seen_addresses == ["1[0]"]
+    assert AddressEcho.seen_addresses == ["[1][0]"]


### PR DESCRIPTION
### Motivation

- Ensure tuple addressing is consistent between core addressing and extension hook addresses by using bracketed notation from the first index (e.g. `"[0]"`, `"[1][0]"`) for unnamed/root tuple paths.

### Description

- Change tuple child address construction in `src/equivalib/core/api.py` so that when `address` is `None` the emitted child address is `f"[{idx}]"` instead of `str(idx)`.
- Update the extension unit test in `tests/test_core_extensions.py` to expect the new canonical unnamed-tuple address `"[1][0]"`.
- Update the extensions documentation `docs/extensions.md` to show examples that use bracket-only tuple child addressing (e.g. `"[0][1]"`).

### Testing

- Ran the targeted test collection with `uv run pytest -q tests/test_core_extensions.py -k 'address_uses_bracket_notation'`, which failed during collection due to a missing dependency: `ModuleNotFoundError: No module named 'ortools'`.
- No other automated tests were executed in this environment because of the missing `ortools` dependency preventing test collection.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4ff6356c832ea54c7d04401588c7)