### PR TITLE
Add root-index Reference helper and support unannotated int bounds via address-based constraints

### DIFF
--- a/docs/spec1.md
+++ b/docs/spec1.md
@@ -117,10 +117,17 @@ The canonical constraints on `Annotated[...]` are:
 - it MAY contain at most one `ValueRange(...)`
 - it MAY contain at most one `Name(...)`
 - if it contains `ValueRange(min, max)`, then `base` MUST be `int`
-- plain `int` MUST NOT appear unless it is immediately annotated with exactly one `ValueRange(...)`
+- every integer leaf MUST be finitely bounded, either directly (for example via
+  `ValueRange(min, max)`) or via numeric constraints on a valid `Reference(label, path)`
+  that points to that leaf
 - `label` MUST be a non-empty string
 
 The value space is finite by construction.
+
+Integer bounds are about the referenced leaf, not about whether the leaf itself
+has a `Name(...)`. For example, in `Annotated[Tuple[int, int], Name("T")]`,
+`Reference("T", (0,))` and `Reference("T", (1,))` MAY provide the required
+bounds for both integer components.
 
 ### Examples of valid trees
 
@@ -241,7 +248,7 @@ The conceptual AST is:
 Expression :=
     BooleanConstant(value)
   | IntegerConstant(value)
-  | Reference(label, path)
+  | Reference(label?, path)
   | Neg(expr)
   | Add(left, right)
   | Sub(left, right)
@@ -261,15 +268,16 @@ Expression :=
 Where:
 
 - `value` is a boolean or integer constant
-- `label` is a `Label`
+- `label` is an optional `Label` (`None` means the root generated value)
 - `path` is a finite tuple of zero-based tuple indices (`0` = first element, `1` = second, etc.)
 
 Examples:
 
 ```python
-Reference("X", ())
-Reference("X", (0,))
-Reference("X", (1, 0))
+reference("X")
+reference("X", 0)
+reference("X", 1, 0)
+reference(0)
 Eq(Reference("X", ()), Reference("Y", ()))
 And(Lt(Reference("X", ()), Reference("Y", ())), Gt(Reference("X", ()), IntegerConstant(0)))
 Or(
@@ -290,7 +298,8 @@ Or(
 
 `Reference(label, path)` means:
 
-- first take the assigned runtime value of `label`
+- if `label` is present, first take the assigned runtime value of that label
+- otherwise, first take the root generated runtime value
 - then follow the tuple indices in `path`
 
 Address evaluation MUST fail if any step:

--- a/src/equivalib/core/__init__.py
+++ b/src/equivalib/core/__init__.py
@@ -5,11 +5,12 @@ Public API surface:
     values           – finite denotation for name-free types
     Name             – symbolic identity marker
     BooleanExpression – convenience constructor (returns BooleanConstant)
+    reference        – convenience constructor for Reference
     mentioned_labels  – collect labels from an expression
     impossible       – exhaustive-match sentinel (NoReturn)
 
 Expression AST constructors:
-    BooleanConstant, IntegerConstant, Reference
+    BooleanConstant, IntegerConstant, Reference, reference
     Neg, Add, Sub, Mul, FloorDiv, Mod
     Eq, Ne, Lt, Le, Gt, Ge
     And, Or
@@ -39,6 +40,7 @@ from equivalib.core.expression import (
     Or,
     Expression,
     BooleanExpression,
+    reference,
     impossible,
 )
 from equivalib.core.api import generate
@@ -55,6 +57,7 @@ __all__ = [
     "Name",
     "Expression",
     "BooleanExpression",
+    "reference",
     "BooleanConstant",
     "IntegerConstant",
     "Reference",

--- a/src/equivalib/core/api.py
+++ b/src/equivalib/core/api.py
@@ -159,10 +159,12 @@ def generate(
 
     # 8. Fast path: no named nodes
     if not contains_name(node):
-        satisfied = eval_expression(constraint_eff, {})
-        if satisfied is not True:
-            return set()
-        return cast("set[GenerateT]", set(_values_node(node)))
+        result_unnamed: set[object] = set()
+        for value in _values_node(node):
+            satisfied = eval_expression(constraint_eff, {None: value})
+            if satisfied is True:
+                result_unnamed.add(value)
+        return cast("set[GenerateT]", result_unnamed)
 
     # 9. Exact satisfying-assignment search (S0)
     assignments = search(node, constraint_eff, methods)

--- a/src/equivalib/core/bounds_inference.py
+++ b/src/equivalib/core/bounds_inference.py
@@ -1,7 +1,7 @@
 """Derive integer bounds from a constraint expression via transitive analysis.
 
 Entry points:
-    infer_int_bounds(node, constraint) -> dict[str, tuple[int, int]]
+    infer_int_bounds(node, constraint) -> dict[RefKey, tuple[int, int]]
     fill_int_bounds(node, bounds) -> IRNode
 """
 
@@ -27,6 +27,9 @@ from equivalib.core.types import (
     UnionNode,
 )
 
+RefKey = tuple[str | None, tuple[int, ...]]
+
+
 def _max_bound(a: int | None, b: int | None) -> int | None:
     """Return the tighter lower bound (max), treating None as −∞."""
     if a is None:
@@ -45,27 +48,52 @@ def _min_bound(a: int | None, b: int | None) -> int | None:
     return min(a, b)
 
 
-def _collect_unbounded_int_labels(node: IRNode) -> frozenset[str]:
-    """Return all label names whose inner node is UnboundedIntNode."""
-    if isinstance(node, NamedNode):
-        if isinstance(node.inner, UnboundedIntNode):
-            return frozenset({node.label})
-        return _collect_unbounded_int_labels(node.inner)
-    if isinstance(node, TupleNode):
-        result: frozenset[str] = frozenset()
-        for item in node.items:
-            result = result | _collect_unbounded_int_labels(item)
-        return result
-    if isinstance(node, UnionNode):
-        result = frozenset()
-        for opt in node.options:
-            result = result | _collect_unbounded_int_labels(opt)
-        return result
-    return frozenset()
+def _collect_unbounded_int_ref_keys(node: IRNode) -> frozenset[RefKey]:
+    """Return all ``(label, path)`` references that point to unbounded ints."""
+
+    def walk_paths(n: IRNode, prefix: tuple[int, ...]) -> frozenset[tuple[int, ...]]:
+        if isinstance(n, UnboundedIntNode):
+            return frozenset({prefix})
+        if isinstance(n, NamedNode):
+            return walk_paths(n.inner, prefix)
+        if isinstance(n, TupleNode):
+            result: frozenset[tuple[int, ...]] = frozenset()
+            for idx, item in enumerate(n.items):
+                result = result | walk_paths(item, prefix + (idx,))
+            return result
+        if isinstance(n, UnionNode):
+            result: frozenset[tuple[int, ...]] = frozenset()
+            for opt in n.options:
+                result = result | walk_paths(opt, prefix)
+            return result
+        return frozenset()
+
+    def walk(n: IRNode) -> frozenset[RefKey]:
+        if isinstance(n, NamedNode):
+            return frozenset((n.label, path) for path in walk_paths(n.inner, ())) | walk(n.inner)
+        if isinstance(n, UnboundedIntNode):
+            return frozenset({(None, ())})
+        if isinstance(n, TupleNode):
+            result: frozenset[RefKey] = frozenset()
+            for idx, item in enumerate(n.items):
+                for label, path in walk(item):
+                    if label is None:
+                        result = result | frozenset({(None, (idx,) + path)})
+                    else:
+                        result = result | frozenset({(label, path)})
+            return result
+        if isinstance(n, UnionNode):
+            result = frozenset()
+            for opt in n.options:
+                result = result | walk(opt)
+            return result
+        return frozenset()
+
+    return walk(node)
 
 
 def _has_cycle_in_rel_lt(
-    rel_lt: list[tuple[str, str]], int_labels: frozenset[str]
+    rel_lt: list[tuple[RefKey, RefKey]], int_refs: frozenset[RefKey]
 ) -> bool:
     """Return True if the strict-inequality graph contains a directed cycle.
 
@@ -73,18 +101,18 @@ def _has_cycle_in_rel_lt(
     bounds are present (where the Bellman-Ford propagation loop would make no
     progress and fall through to the "missing bounds" error instead).
     """
-    graph: dict[str, list[str]] = {label: [] for label in int_labels}
+    graph: dict[RefKey, list[RefKey]] = {key: [] for key in int_refs}
     for x, y in rel_lt:
-        if x in graph and y in int_labels:
+        if x in graph and y in int_refs:
             graph[x].append(y)
 
     WHITE, GRAY, BLACK = 0, 1, 2
-    color: dict[str, int] = {label: WHITE for label in int_labels}
+    color: dict[RefKey, int] = {key: WHITE for key in int_refs}
 
-    for start in int_labels:
+    for start in int_refs:
         if color[start] != WHITE:
             continue
-        stack: list[tuple[str, object]] = [(start, iter(graph[start]))]
+        stack: list[tuple[RefKey, object]] = [(start, iter(graph[start]))]
         color[start] = GRAY
         while stack:
             node, neighbors = stack[-1]
@@ -118,116 +146,111 @@ def _flatten_and(expr: Expression) -> list[Expression]:
 
 def _try_extract_bound(
     expr: Expression,
-    int_labels: frozenset[str],
-    direct_lo: dict[str, int],
-    direct_hi: dict[str, int],
-    rel_lt: list[tuple[str, str]],
-    rel_le: list[tuple[str, str]],
-    rel_eq: list[tuple[str, str]],
+    int_refs: frozenset[RefKey],
+    direct_lo: dict[RefKey, int],
+    direct_hi: dict[RefKey, int],
+    rel_lt: list[tuple[RefKey, RefKey]],
+    rel_le: list[tuple[RefKey, RefKey]],
+    rel_eq: list[tuple[RefKey, RefKey]],
 ) -> None:
     """Extract a bound from a simple comparison conjunct, if possible."""
 
-    def is_plain_ref(e: Expression) -> bool:
-        return isinstance(e, Reference) and not e.path and e.label in int_labels
+    def ref_key(e: Expression) -> RefKey | None:
+        if not isinstance(e, Reference):
+            return None
+        key = (e.label, e.path)
+        if key not in int_refs:
+            return None
+        return key
 
     def is_int_const(e: Expression) -> bool:
         return isinstance(e, IntegerConstant)
 
     if isinstance(expr, Ge):
-        if is_plain_ref(expr.left) and is_int_const(expr.right):
-            label = expr.left.label  # type: ignore[union-attr]
+        left_key = ref_key(expr.left)
+        right_key = ref_key(expr.right)
+        if left_key is not None and is_int_const(expr.right):
             n = expr.right.value  # type: ignore[union-attr]
-            direct_lo[label] = n if label not in direct_lo else max(direct_lo[label], n)
-        elif is_int_const(expr.left) and is_plain_ref(expr.right):
-            label = expr.right.label  # type: ignore[union-attr]
+            direct_lo[left_key] = n if left_key not in direct_lo else max(direct_lo[left_key], n)
+        elif is_int_const(expr.left) and right_key is not None:
             n = expr.left.value  # type: ignore[union-attr]
-            direct_hi[label] = n if label not in direct_hi else min(direct_hi[label], n)
-        elif is_plain_ref(expr.left) and is_plain_ref(expr.right):
-            lx = expr.left.label  # type: ignore[union-attr]
-            ry = expr.right.label  # type: ignore[union-attr]
-            rel_le.append((ry, lx))
+            direct_hi[right_key] = n if right_key not in direct_hi else min(direct_hi[right_key], n)
+        elif left_key is not None and right_key is not None:
+            rel_le.append((right_key, left_key))
 
     elif isinstance(expr, Le):
-        if is_plain_ref(expr.left) and is_int_const(expr.right):
-            label = expr.left.label  # type: ignore[union-attr]
+        left_key = ref_key(expr.left)
+        right_key = ref_key(expr.right)
+        if left_key is not None and is_int_const(expr.right):
             n = expr.right.value  # type: ignore[union-attr]
-            direct_hi[label] = n if label not in direct_hi else min(direct_hi[label], n)
-        elif is_int_const(expr.left) and is_plain_ref(expr.right):
-            label = expr.right.label  # type: ignore[union-attr]
+            direct_hi[left_key] = n if left_key not in direct_hi else min(direct_hi[left_key], n)
+        elif is_int_const(expr.left) and right_key is not None:
             n = expr.left.value  # type: ignore[union-attr]
-            direct_lo[label] = n if label not in direct_lo else max(direct_lo[label], n)
-        elif is_plain_ref(expr.left) and is_plain_ref(expr.right):
-            lx = expr.left.label  # type: ignore[union-attr]
-            ry = expr.right.label  # type: ignore[union-attr]
-            rel_le.append((lx, ry))
+            direct_lo[right_key] = n if right_key not in direct_lo else max(direct_lo[right_key], n)
+        elif left_key is not None and right_key is not None:
+            rel_le.append((left_key, right_key))
 
     elif isinstance(expr, Gt):
-        if is_plain_ref(expr.left) and is_int_const(expr.right):
-            label = expr.left.label  # type: ignore[union-attr]
+        left_key = ref_key(expr.left)
+        right_key = ref_key(expr.right)
+        if left_key is not None and is_int_const(expr.right):
             n = expr.right.value  # type: ignore[union-attr]
-            direct_lo[label] = n + 1 if label not in direct_lo else max(direct_lo[label], n + 1)
-        elif is_int_const(expr.left) and is_plain_ref(expr.right):
-            label = expr.right.label  # type: ignore[union-attr]
+            direct_lo[left_key] = n + 1 if left_key not in direct_lo else max(direct_lo[left_key], n + 1)
+        elif is_int_const(expr.left) and right_key is not None:
             n = expr.left.value  # type: ignore[union-attr]
-            direct_hi[label] = n - 1 if label not in direct_hi else min(direct_hi[label], n - 1)
-        elif is_plain_ref(expr.left) and is_plain_ref(expr.right):
-            lx = expr.left.label  # type: ignore[union-attr]
-            ry = expr.right.label  # type: ignore[union-attr]
-            rel_lt.append((ry, lx))
+            direct_hi[right_key] = n - 1 if right_key not in direct_hi else min(direct_hi[right_key], n - 1)
+        elif left_key is not None and right_key is not None:
+            rel_lt.append((right_key, left_key))
 
     elif isinstance(expr, Lt):
-        if is_plain_ref(expr.left) and is_int_const(expr.right):
-            label = expr.left.label  # type: ignore[union-attr]
+        left_key = ref_key(expr.left)
+        right_key = ref_key(expr.right)
+        if left_key is not None and is_int_const(expr.right):
             n = expr.right.value  # type: ignore[union-attr]
-            direct_hi[label] = n - 1 if label not in direct_hi else min(direct_hi[label], n - 1)
-        elif is_int_const(expr.left) and is_plain_ref(expr.right):
-            label = expr.right.label  # type: ignore[union-attr]
+            direct_hi[left_key] = n - 1 if left_key not in direct_hi else min(direct_hi[left_key], n - 1)
+        elif is_int_const(expr.left) and right_key is not None:
             n = expr.left.value  # type: ignore[union-attr]
-            direct_lo[label] = n + 1 if label not in direct_lo else max(direct_lo[label], n + 1)
-        elif is_plain_ref(expr.left) and is_plain_ref(expr.right):
-            lx = expr.left.label  # type: ignore[union-attr]
-            ry = expr.right.label  # type: ignore[union-attr]
-            rel_lt.append((lx, ry))
+            direct_lo[right_key] = n + 1 if right_key not in direct_lo else max(direct_lo[right_key], n + 1)
+        elif left_key is not None and right_key is not None:
+            rel_lt.append((left_key, right_key))
 
     elif isinstance(expr, Eq):
-        if is_plain_ref(expr.left) and is_int_const(expr.right):
-            label = expr.left.label  # type: ignore[union-attr]
+        left_key = ref_key(expr.left)
+        right_key = ref_key(expr.right)
+        if left_key is not None and is_int_const(expr.right):
             n = expr.right.value  # type: ignore[union-attr]
-            direct_lo[label] = n if label not in direct_lo else max(direct_lo[label], n)
-            direct_hi[label] = n if label not in direct_hi else min(direct_hi[label], n)
-        elif is_int_const(expr.left) and is_plain_ref(expr.right):
-            label = expr.right.label  # type: ignore[union-attr]
+            direct_lo[left_key] = n if left_key not in direct_lo else max(direct_lo[left_key], n)
+            direct_hi[left_key] = n if left_key not in direct_hi else min(direct_hi[left_key], n)
+        elif is_int_const(expr.left) and right_key is not None:
             n = expr.left.value  # type: ignore[union-attr]
-            direct_lo[label] = n if label not in direct_lo else max(direct_lo[label], n)
-            direct_hi[label] = n if label not in direct_hi else min(direct_hi[label], n)
-        elif is_plain_ref(expr.left) and is_plain_ref(expr.right):
-            lx = expr.left.label  # type: ignore[union-attr]
-            ry = expr.right.label  # type: ignore[union-attr]
-            rel_eq.append((lx, ry))
+            direct_lo[right_key] = n if right_key not in direct_lo else max(direct_lo[right_key], n)
+            direct_hi[right_key] = n if right_key not in direct_hi else min(direct_hi[right_key], n)
+        elif left_key is not None and right_key is not None:
+            rel_eq.append((left_key, right_key))
 
 
 def infer_int_bounds(
     node: IRNode,
     constraint: Expression,
-) -> dict[str, tuple[int, int]]:
-    """Infer lower and upper bounds for each named unbounded integer in the tree."""
-    int_labels = _collect_unbounded_int_labels(node)
-    if not int_labels:
+) -> dict[RefKey, tuple[int, int]]:
+    """Infer lower and upper bounds for each addressable unbounded integer in the tree."""
+    int_refs = _collect_unbounded_int_ref_keys(node)
+    if not int_refs:
         return {}
 
     # None means "unbounded" (lo: −∞, hi: +∞). Using int|None avoids float
     # arithmetic entirely, which preserves precision for large integer constants.
-    lo: dict[str, int | None] = {label: None for label in int_labels}
-    hi: dict[str, int | None] = {label: None for label in int_labels}
+    lo: dict[RefKey, int | None] = {key: None for key in int_refs}
+    hi: dict[RefKey, int | None] = {key: None for key in int_refs}
 
-    direct_lo: dict[str, int] = {}
-    direct_hi: dict[str, int] = {}
-    rel_lt: list[tuple[str, str]] = []
-    rel_le: list[tuple[str, str]] = []
-    rel_eq: list[tuple[str, str]] = []
+    direct_lo: dict[RefKey, int] = {}
+    direct_hi: dict[RefKey, int] = {}
+    rel_lt: list[tuple[RefKey, RefKey]] = []
+    rel_le: list[tuple[RefKey, RefKey]] = []
+    rel_eq: list[tuple[RefKey, RefKey]] = []
 
     for conjunct in _flatten_and(constraint):
-        _try_extract_bound(conjunct, int_labels, direct_lo, direct_hi, rel_lt, rel_le, rel_eq)
+        _try_extract_bound(conjunct, int_refs, direct_lo, direct_hi, rel_lt, rel_le, rel_eq)
 
     for label, v in direct_lo.items():
         lo[label] = _max_bound(lo[label], v)
@@ -238,8 +261,8 @@ def infer_int_bounds(
     # Cycles are contradictions for integers, and must be caught before the
     # fixed-point loop because the loop makes no progress when no finite bounds
     # are present to propagate.
-    if any(x == y for (x, y) in rel_lt) or _has_cycle_in_rel_lt(rel_lt, int_labels):
-        return {label: (1, 0) for label in int_labels}
+    if any(x == y for (x, y) in rel_lt) or _has_cycle_in_rel_lt(rel_lt, int_refs):
+        return {key: (1, 0) for key in int_refs}
 
     # Propagate bounds to a fixed point.
     changed = True
@@ -286,54 +309,68 @@ def infer_int_bounds(
         # Short-circuit as soon as any bounds become contradictory (lo > hi).
         # Some unrelated labels may still have no bounds here, so return an
         # explicit unsatisfiable sentinel instead of propagating further.
-        for label in int_labels:
-            lo_v, hi_v = lo[label], hi[label]
+        for key in int_refs:
+            lo_v, hi_v = lo[key], hi[key]
             if lo_v is not None and hi_v is not None and lo_v > hi_v:
-                return {label: (1, 0) for label in int_labels}
+                return {rkey: (1, 0) for rkey in int_refs}
 
     missing: list[str] = []
-    for label in sorted(int_labels):
-        if lo[label] is None:
-            missing.append(f"lower bound for {label!r}")
-        if hi[label] is None:
-            missing.append(f"upper bound for {label!r}")
+    for label, path in sorted(int_refs, key=lambda k: ("" if k[0] is None else k[0], k[1])):
+        target = f"{label!r}{path!r}"
+        if lo[(label, path)] is None:
+            missing.append(f"lower bound for {target}")
+        if hi[(label, path)] is None:
+            missing.append(f"upper bound for {target}")
 
     if missing:
         raise ValueError(
-            f"Could not derive bounds for the following integer labels from the constraint: "
+            f"Could not derive bounds for the following integer references from the constraint: "
             f"{', '.join(missing)}. "
             "Add explicit bound constraints using Ge, Le, Gt, Lt, or Eq "
-            "(e.g. And(Ge(ref('X'), IntegerConstant(0)), Le(ref('X'), IntegerConstant(9))))."
+            "(e.g. And(Ge(ref('X'), IntegerConstant(0)), Le(ref('X'), IntegerConstant(9))) "
+            "or using address paths like ref('T', (0,)))."
         )
 
     # At this point all bounds are confirmed non-None (missing is empty).
-    result: dict[str, tuple[int, int]] = {}
-    for label in int_labels:
-        lo_v = lo[label]
-        hi_v = hi[label]
+    result: dict[RefKey, tuple[int, int]] = {}
+    for key in int_refs:
+        lo_v = lo[key]
+        hi_v = hi[key]
         assert lo_v is not None and hi_v is not None  # guaranteed by missing-check above
-        result[label] = (lo_v, hi_v)
+        result[key] = (lo_v, hi_v)
     return result
 
 
-def fill_int_bounds(node: IRNode, bounds: dict[str, tuple[int, int]]) -> IRNode:
-    """Replace every NamedNode(label, UnboundedIntNode()) with NamedNode(label, IntRangeNode(lo, hi))."""
+def fill_int_bounds(node: IRNode, bounds: dict[RefKey, tuple[int, int]]) -> IRNode:
+    """Replace every addressable ``UnboundedIntNode`` with the inferred ``IntRangeNode``."""
+
+    def fill(n: IRNode, current_label: str | None, path: tuple[int, ...]) -> IRNode:
+        if isinstance(n, NamedNode):
+            new_inner = fill(n.inner, n.label, ())
+            if new_inner is n.inner:
+                return n
+            return NamedNode(n.label, new_inner)
+        if isinstance(n, UnboundedIntNode):
+            lo, hi = bounds[(current_label, path)]
+            return IntRangeNode(lo, hi)
+        if isinstance(n, TupleNode):
+            new_items = tuple(fill(item, current_label, path + (idx,)) for idx, item in enumerate(n.items))
+            if new_items == n.items:
+                return n
+            return TupleNode(new_items)
+        if isinstance(n, UnionNode):
+            new_options = tuple(fill(opt, current_label, path) for opt in n.options)
+            if new_options == n.options:
+                return n
+            return UnionNode(new_options)
+        return n
+
+    filled = fill(node, None, ())
     if isinstance(node, NamedNode):
-        if isinstance(node.inner, UnboundedIntNode):
-            lo, hi = bounds[node.label]
-            return NamedNode(node.label, IntRangeNode(lo, hi))
-        new_inner = fill_int_bounds(node.inner, bounds)
-        if new_inner is node.inner:
-            return node
-        return NamedNode(node.label, new_inner)
+        # keep static type narrow for callers
+        return filled
     if isinstance(node, TupleNode):
-        new_items = tuple(fill_int_bounds(item, bounds) for item in node.items)
-        if new_items == node.items:
-            return node
-        return TupleNode(new_items)
+        return filled
     if isinstance(node, UnionNode):
-        new_options = tuple(fill_int_bounds(opt, bounds) for opt in node.options)
-        if new_options == node.options:
-            return node
-        return UnionNode(new_options)
-    return node
+        return filled
+    return filled

--- a/src/equivalib/core/cache.py
+++ b/src/equivalib/core/cache.py
@@ -71,7 +71,8 @@ def _collect_labels(expr: Expression, out: set[str]) -> None:
     if isinstance(expr, (BooleanConstant, IntegerConstant)):
         return
     if isinstance(expr, Reference):
-        out.add(expr.label)
+        if expr.label is not None:
+            out.add(expr.label)
         return
     if isinstance(expr, Neg):
         _collect_labels(expr.operand, out)

--- a/src/equivalib/core/eval.py
+++ b/src/equivalib/core/eval.py
@@ -63,7 +63,7 @@ Unknown = _UnknownType()
 # Tuple path addressing helper
 # ---------------------------------------------------------------------------
 
-def _follow_reference_path(value: object, path: tuple[int, ...], label: str) -> object:
+def _follow_reference_path(value: object, path: tuple[int, ...], label: str | None) -> object:
     """Follow ``path`` into ``value`` using strict zero-based tuple indexing."""
     current = value
     for depth, idx in enumerate(path):
@@ -106,7 +106,7 @@ def _structural_eq(lv: object, rv: object) -> bool:
 # Full evaluation (all labels must be assigned)
 # ---------------------------------------------------------------------------
 
-def eval_expression(expr: Expression, assignment: dict[str, object]) -> object:
+def eval_expression(expr: Expression, assignment: dict[object, object]) -> object:
     """Evaluate ``expr`` against a complete assignment mapping.
 
     ``assignment`` maps label strings to runtime values.
@@ -115,7 +115,7 @@ def eval_expression(expr: Expression, assignment: dict[str, object]) -> object:
     return _eval(expr, assignment)
 
 
-def _eval(expr: Expression, assignment: dict[str, object]) -> object:
+def _eval(expr: Expression, assignment: dict[object, object]) -> object:
     if isinstance(expr, BooleanConstant):
         return expr.value
     if isinstance(expr, IntegerConstant):
@@ -158,7 +158,7 @@ def _eval(expr: Expression, assignment: dict[str, object]) -> object:
 # Partial evaluation (some labels may be unresolved)
 # ---------------------------------------------------------------------------
 
-def eval_expression_partial(expr: Expression, partial_assignment: dict[str, object]) -> object:
+def eval_expression_partial(expr: Expression, partial_assignment: dict[object, object]) -> object:
     """Evaluate ``expr`` against a partial assignment.
 
     Returns a concrete value if it can be determined, or ``Unknown`` if the
@@ -167,7 +167,7 @@ def eval_expression_partial(expr: Expression, partial_assignment: dict[str, obje
     return _eval_partial(expr, partial_assignment)
 
 
-def _eval_partial(expr: Expression, pa: dict[str, object]) -> object:
+def _eval_partial(expr: Expression, pa: dict[object, object]) -> object:
     if isinstance(expr, BooleanConstant):
         return expr.value
     if isinstance(expr, IntegerConstant):

--- a/src/equivalib/core/expression.py
+++ b/src/equivalib/core/expression.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import NoReturn, Union
+from typing import NoReturn, Optional, Sequence, Union
 
 
 # ---------------------------------------------------------------------------
@@ -26,14 +26,18 @@ class IntegerConstant:
 
 @dataclass(frozen=True)
 class Reference:
-    """A reference to a named label, with an optional address path into tuples.
+    """A reference to a leaf.
 
     ``path`` is a tuple of zero-based integer indices.  An empty path refers
     to the whole value bound to ``label``.
+    By default, ``label`` is the root of the expression.
     """
 
-    label: str
-    path: tuple[int, ...] = ()
+    label: Optional[str] = None
+    path: Sequence[int] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "path", tuple(self.path))
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +176,20 @@ def BooleanExpression(value: bool) -> BooleanConstant:
     ``BooleanExpression(True)`` is the canonical unconstrained expression.
     """
     return BooleanConstant(value)
+
+
+def reference(first: Union[str, int], *rest: int) -> Reference:
+    """Build a :class:`Reference` from either a label or a root index path.
+
+    Examples:
+        ``reference("X")`` -> ``Reference("X", ())``
+        ``reference("X", 0, 1)`` -> ``Reference("X", (0, 1))``
+        ``reference(0)`` -> ``Reference(None, (0,))``
+        ``reference(0, 1)`` -> ``Reference(None, (0, 1))``
+    """
+    if isinstance(first, str):
+        return Reference(label=first, path=tuple(rest))
+    return Reference(label=None, path=(first, *rest))
 
 
 def impossible(x: NoReturn) -> NoReturn:

--- a/src/equivalib/core/normalize.py
+++ b/src/equivalib/core/normalize.py
@@ -49,10 +49,7 @@ def normalize(t: object) -> IRNode:
         return BoolNode()
 
     if t is int:
-        raise ValueError(
-            "Plain 'int' is not supported. "
-            "Use Annotated[int, Name('X')] with bounds provided via the constraint parameter."
-        )
+        return UnboundedIntNode()
 
     if origin is typing.Literal:
         _SUPPORTED_LITERAL_TYPES = (type(None), bool, int, str)
@@ -113,11 +110,6 @@ def _normalize_annotated(base: object, metadata: list[object]) -> IRNode:
         raise ValueError("Name label must not be empty.")
 
     if base is int:
-        if name is None:
-            raise ValueError(
-                "An 'int' in Annotated requires a Name(...) annotation. "
-                "Use Annotated[int, Name('X')] and supply bounds via the constraint parameter."
-            )
         inner: IRNode = UnboundedIntNode()
     else:
         inner = normalize(base)

--- a/src/equivalib/core/types.py
+++ b/src/equivalib/core/types.py
@@ -58,7 +58,7 @@ class IntRangeNode:
 
 @dataclass(frozen=True)
 class UnboundedIntNode:
-    """Placeholder for a named integer whose bounds are to be inferred from the constraint."""
+    """Placeholder for an integer whose bounds are inferred from constraint references."""
 
 
 @dataclass(frozen=True)

--- a/src/equivalib/core/validate.py
+++ b/src/equivalib/core/validate.py
@@ -145,17 +145,32 @@ def validate_expression(expr: Expression, node: IRNode) -> None:
     - numeric operations have numeric operands, etc.
     """
     known_labels = tree_labels(node)
+    if contains_name(node) and _contains_root_reference(expr):
+        raise ValueError("Root references (reference(0, ...)) are only supported for trees without Name(...) labels.")
 
     # Build a label -> shape map for address validation
     label_shapes = _collect_label_shapes(node)
+    root_shape = tree_shape(node)
 
     # Type-check the top-level expression: must be boolean-typed
-    result_type = _check_expr_type(expr, known_labels, label_shapes)
+    result_type = _check_expr_type(expr, known_labels, label_shapes, root_shape)
     if result_type != "bool":
         raise TypeError(
             f"Top-level constraint must be a boolean expression, "
             f"got {result_type!r}: {expr!r}."
         )
+
+
+def _contains_root_reference(expr: Expression) -> bool:
+    if isinstance(expr, Reference):
+        return expr.label is None
+    if isinstance(expr, (BooleanConstant, IntegerConstant)):
+        return False
+    if isinstance(expr, Neg):
+        return _contains_root_reference(expr.operand)
+    if isinstance(expr, (Add, Sub, Mul, FloorDiv, Mod, Eq, Ne, Lt, Le, Gt, Ge, And, Or)):
+        return _contains_root_reference(expr.left) or _contains_root_reference(expr.right)
+    impossible(expr)
 
 
 def _collect_label_shapes(node: IRNode) -> LabelShapes:
@@ -206,7 +221,9 @@ def _merge_shapes(left: IRNode, right: IRNode) -> IRNode:
     return UnionNode(tuple(dedup))
 
 
-def _check_expr_type(expr: Expression, known_labels: frozenset[str], label_shapes: LabelShapes) -> ExprType:
+def _check_expr_type(
+    expr: Expression, known_labels: frozenset[str], label_shapes: LabelShapes, root_shape: IRNode
+) -> ExprType:
     """Return 'bool', 'numeric', or 'any' (or raise if invalid).
 
     'any' is returned for expressions whose type cannot be resolved to
@@ -222,6 +239,10 @@ def _check_expr_type(expr: Expression, known_labels: frozenset[str], label_shape
         return "numeric"
 
     if isinstance(expr, Reference):
+        if expr.label is None:
+            _validate_address("<root>", expr.path, root_shape)
+            resolved = _resolve_shape(root_shape, expr.path)
+            return _shape_type(resolved)
         if expr.label not in known_labels:
             raise ValueError(
                 f"Reference to unknown label {expr.label!r}. "
@@ -238,33 +259,33 @@ def _check_expr_type(expr: Expression, known_labels: frozenset[str], label_shape
         return "any"
 
     if isinstance(expr, Neg):
-        t = _check_expr_type(expr.operand, known_labels, label_shapes)
+        t = _check_expr_type(expr.operand, known_labels, label_shapes, root_shape)
         if t != "numeric":
             raise TypeError(f"Neg operand must be numeric, got {t!r}: {expr!r}")
         return "numeric"
 
     if isinstance(expr, (Add, Sub, Mul, FloorDiv, Mod)):
-        lt = _check_expr_type(expr.left, known_labels, label_shapes)
-        rt = _check_expr_type(expr.right, known_labels, label_shapes)
+        lt = _check_expr_type(expr.left, known_labels, label_shapes, root_shape)
+        rt = _check_expr_type(expr.right, known_labels, label_shapes, root_shape)
         if lt != "numeric" or rt != "numeric":
             raise TypeError(f"Arithmetic operands must be numeric, got ({lt!r}, {rt!r}): {expr!r}")
         return "numeric"
 
     if isinstance(expr, (Eq, Ne)):
-        _check_expr_type(expr.left, known_labels, label_shapes)
-        _check_expr_type(expr.right, known_labels, label_shapes)
+        _check_expr_type(expr.left, known_labels, label_shapes, root_shape)
+        _check_expr_type(expr.right, known_labels, label_shapes, root_shape)
         return "bool"
 
     if isinstance(expr, (Lt, Le, Gt, Ge)):
-        lt = _check_expr_type(expr.left, known_labels, label_shapes)
-        rt = _check_expr_type(expr.right, known_labels, label_shapes)
+        lt = _check_expr_type(expr.left, known_labels, label_shapes, root_shape)
+        rt = _check_expr_type(expr.right, known_labels, label_shapes, root_shape)
         if lt != "numeric" or rt != "numeric":
             raise TypeError(f"Ordering operands must be numeric, got ({lt!r}, {rt!r}): {expr!r}")
         return "bool"
 
     if isinstance(expr, (And, Or)):
-        lt = _check_expr_type(expr.left, known_labels, label_shapes)
-        rt = _check_expr_type(expr.right, known_labels, label_shapes)
+        lt = _check_expr_type(expr.left, known_labels, label_shapes, root_shape)
+        rt = _check_expr_type(expr.right, known_labels, label_shapes, root_shape)
         if lt != "bool":
             raise TypeError(f"{type(expr).__name__} left operand must be boolean, got {lt!r}: {expr!r}")
         if rt != "bool":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,7 +26,6 @@ from equivalib.core.expression import (
     Ne,
     Neg,
     Or,
-    Reference,
 )
 from equivalib.core.methods import apply_methods
 from equivalib.core.name import Name as CoreName
@@ -68,12 +67,16 @@ def int_const(value: int) -> Any:
     return core_attr("IntegerConstant")(value)
 
 
-def ref(label: str, path: tuple[int, ...] = ()) -> Any:  # noqa: D401
-    return core_attr("Reference")(label, path)
+def ref(first: Any, path: tuple[int, ...] = ()) -> Any:  # noqa: D401
+    if isinstance(first, str):
+        return core_attr("reference")(first, *path)
+    if isinstance(first, int):
+        return core_attr("reference")(first, *path)
+    raise TypeError("ref(...) first argument must be str or int")
 
 
 def _int_bounds(label: str, lo: int, hi: int) -> Any:
-    """Return a bounds constraint for a named int label: lo <= label <= hi."""
+    """Return bounds on an integer reference: lo <= ref(label) <= hi."""
     return And(Ge(ref(label), int_const(lo)), Le(ref(label), int_const(hi)))
 
 
@@ -84,6 +87,7 @@ def test_core_exports_generate_and_ast_surface():
     assert core_attr("BooleanConstant")
     assert core_attr("IntegerConstant")
     assert core_attr("Reference")
+    assert core_attr("reference")
     assert core_attr("Eq")
     assert core_attr("Ne")
     assert core_attr("Lt")
@@ -476,6 +480,89 @@ def test_generate_rejects_unknown_annotated_metadata():
         generate(Annotated[bool, "mystery"], true_expr(), {})
 
 
+def test_generate_accepts_address_bounded_ints_inside_named_tuple():
+    generate = core_attr("generate")
+    Name = core_attr("Name")
+    tree = Annotated[Tuple[int, int], Name("T")]
+    a = ref("T", (0,))
+    b = ref("T", (1,))
+    constraint = And(
+        And(Ge(a, int_const(1)), Le(a, int_const(2))),
+        And(Ge(b, int_const(3)), Le(b, int_const(4))),
+    )
+    assert generate(tree, constraint, {"T": "all"}) == {
+        (1, 3),
+        (1, 4),
+        (2, 3),
+        (2, 4),
+    }
+
+
+def test_generate_accepts_address_bounded_ints_without_annotations():
+    generate = core_attr("generate")
+    tree = Tuple[int, int]
+    a = ref(0)
+    b = ref(1)
+    constraint = And(
+        And(Ge(a, int_const(1)), Le(a, int_const(2))),
+        And(Ge(b, int_const(3)), Le(b, int_const(4))),
+    )
+    assert generate(tree, constraint, {}) == {
+        (1, 3),
+        (1, 4),
+        (2, 3),
+        (2, 4),
+    }
+
+
+def test_generate_accepts_address_bounded_ints_inside_named_tuple_2():
+    generate = core_attr("generate")
+    tree = Tuple[int, int]
+    a = ref(0)
+    b = ref(1)
+    constraint = And(
+        And(Ge(a, int_const(1)), Le(a, int_const(2))),
+        And(Ge(b, int_const(3)), Le(b, int_const(4))),
+    )
+    assert generate(tree, constraint, {}) == {
+        (1, 3),
+        (1, 4),
+        (2, 3),
+        (2, 4),
+    }
+
+
+def test_generate_arbitrary_works_with_unannotated_address_bounded_ints():
+    generate = core_attr("generate")
+    tree = Tuple[int, int, int]
+    x = ref(0)
+    y = ref(1)
+    z = ref(2)
+    bounded = And(
+        And(Ge(x, int_const(0)), Le(x, int_const(9))),
+        And(And(Ge(y, int_const(0)), Le(y, int_const(9))), And(Ge(z, int_const(0)), Le(z, int_const(9)))),
+    )
+    values = generate(tree, And(bounded, Eq(Add(Add(x, y), z), int_const(7))), {})
+    assert len(values) == 36
+
+
+def test_generate_arbitrary_method_works_with_address_bounded_ints():
+    generate = core_attr("generate")
+    Name = core_attr("Name")
+    tree = Annotated[Tuple[int, int, int], Name("T")]
+    x = ref("T", (0,))
+    y = ref("T", (1,))
+    z = ref("T", (2,))
+    bounded = And(
+        And(Ge(x, int_const(0)), Le(x, int_const(9))),
+        And(And(Ge(y, int_const(0)), Le(y, int_const(9))), And(Ge(z, int_const(0)), Le(z, int_const(9)))),
+    )
+    values = generate(tree, And(bounded, Eq(Add(Add(x, y), z), int_const(7))), {"T": "arbitrary"})
+    assert len(values) == 1
+    only = next(iter(values))
+    assert sum(only) == 7
+
+
 def test_generate_rejects_constraint_on_missing_label():
     generate = core_attr("generate")
     Name = core_attr("Name")
@@ -762,7 +849,7 @@ def test_validate_rejects_non_int_path_element():
     """A Reference with a non-int path element (e.g. str) must be rejected."""
     tree_node = NamedNode("X", TupleNode((BoolNode(),)))
     # Python does not enforce type annotations at runtime, so this constructs fine
-    expr = Reference("X", ("0",))  # type: ignore[arg-type]
+    expr = ref("X", ("0",))  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="plain int"):
         validate_expression(expr, tree_node)
 
@@ -770,7 +857,7 @@ def test_validate_rejects_non_int_path_element():
 def test_validate_rejects_bool_path_element():
     """A Reference with a bool path element must be rejected (bool is not a plain int index)."""
     tree_node = NamedNode("X", TupleNode((BoolNode(),)))
-    expr = Reference("X", (True,))  # bool is a subclass of int, so this type-checks
+    expr = ref("X", (True,))  # bool is a subclass of int, so this type-checks
     with pytest.raises(ValueError, match="plain int"):
         validate_expression(expr, tree_node)
 
@@ -897,32 +984,32 @@ def test_generate_rejects_ordering_on_any_typed_reference():
 
 
 def test_eval_full_expression_basic_arithmetic():
-    expr = Add(Mul(Reference("x"), IntegerConstant(3)), IntegerConstant(1))
+    expr = Add(Mul(ref("x"), IntegerConstant(3)), IntegerConstant(1))
     assert eval_expression(expr, {"x": 4}) == 13
 
 
 def test_eval_partial_and_short_circuits_on_false():
-    expr = And(BooleanConstant(False), Reference("y"))
+    expr = And(BooleanConstant(False), ref("y"))
     assert eval_expression_partial(expr, {}) is False
 
 
 def test_eval_partial_or_short_circuits_on_true():
-    expr = Or(BooleanConstant(True), Reference("y"))
+    expr = Or(BooleanConstant(True), ref("y"))
     assert eval_expression_partial(expr, {}) is True
 
 
 def test_eval_partial_unknown_propagates_through_arithmetic():
-    expr = Add(Reference("x"), IntegerConstant(1))
+    expr = Add(ref("x"), IntegerConstant(1))
     assert eval_expression_partial(expr, {}) is Unknown
 
 
 def test_eval_partial_and_both_unknown():
-    expr = And(Reference("x"), Reference("y"))
+    expr = And(ref("x"), ref("y"))
     assert eval_expression_partial(expr, {}) is Unknown
 
 
 def test_eval_partial_neg_of_unknown():
-    expr = Neg(Reference("x"))
+    expr = Neg(ref("x"))
     assert eval_expression_partial(expr, {}) is Unknown
 
 
@@ -1066,14 +1153,14 @@ def test_structural_eq_distinguishes_bool_from_int():
 
 def test_eval_eq_type_aware():
     """eval_expression(Eq(...)) must use structural equality."""
-    expr = Eq(Reference("X"), IntegerConstant(1))
+    expr = Eq(ref("X"), IntegerConstant(1))
     assert eval_expression(expr, {"X": 1}) is True
     assert eval_expression(expr, {"X": True}) is False  # True == 1 in Python, but Eq is structural
 
 
 def test_eval_ne_type_aware():
     """eval_expression(Ne(...)) must use structural equality."""
-    expr = Ne(Reference("X"), IntegerConstant(1))
+    expr = Ne(ref("X"), IntegerConstant(1))
     assert eval_expression(expr, {"X": 1}) is False
     assert eval_expression(expr, {"X": True}) is True  # True != 1 structurally
 
@@ -1143,13 +1230,13 @@ def test_is_label_closed_single_label():
 
 def test_is_constraint_independent_disjoint_labels():
     subtree = normalize(Annotated[bool, CoreName("X")])
-    constraint = Reference("Y")
+    constraint = ref("Y")
     assert is_constraint_independent(subtree, constraint) is True
 
 
 def test_is_constraint_independent_overlapping_labels():
     subtree = normalize(Annotated[bool, CoreName("X")])
-    constraint = Reference("X")
+    constraint = ref("X")
     assert is_constraint_independent(subtree, constraint) is False
 
 
@@ -1160,7 +1247,7 @@ def test_is_guaranteed_cacheable_unnamed():
 
 def test_is_guaranteed_cacheable_label_closed_and_independent():
     node = normalize(Annotated[bool, CoreName("X")])
-    constraint = Reference("Y")
+    constraint = ref("Y")
     assert is_guaranteed_cacheable(node, node, constraint) is True
 
 
@@ -2269,7 +2356,7 @@ def test_floordiv_undefined_divisor_no_duplicate_sat_assignments():
     (B, Y) label assignment, not one per (q, r) combination.
     """
     node = TupleNode((NamedNode("B", BoolNode()), NamedNode("Y", IntRangeNode(0, 1))))
-    constraint = Or(Reference("B", ()), Eq(FloorDiv(IntegerConstant(1), Reference("Y", ())), IntegerConstant(0)))
+    constraint = Or(ref("B"), Eq(FloorDiv(IntegerConstant(1), ref("Y")), IntegerConstant(0)))
     assignments = _sat_search(node, constraint)
     seen: set[frozenset[tuple[str, object]]] = set()
     for asgn in assignments:
@@ -2284,7 +2371,7 @@ def test_mod_undefined_divisor_no_duplicate_sat_assignments():
     Same as the FloorDiv test but using Mod.
     """
     node = TupleNode((NamedNode("B", BoolNode()), NamedNode("Y", IntRangeNode(0, 1))))
-    constraint = Or(Reference("B", ()), Eq(Mod(IntegerConstant(1), Reference("Y", ())), IntegerConstant(0)))
+    constraint = Or(ref("B"), Eq(Mod(IntegerConstant(1), ref("Y")), IntegerConstant(0)))
     assignments = _sat_search(node, constraint)
     seen: set[frozenset[tuple[str, object]]] = set()
     for asgn in assignments:
@@ -2314,7 +2401,7 @@ def test_reference_path_into_enum_tuple_in_reify_constraint():
         )
     )
     # T is always (True, False); T[0]=True, so Or(B, True) must admit B=False too.
-    constraint = Or(Reference("B", ()), Reference("T", (0,)))
+    constraint = Or(ref("B"), ref("T", (0,)))
     assignments = _sat_search(node, constraint)
     pairs = {(a["B"], a["T"]) for a in assignments}
     expected = {(True, (True, False)), (False, (True, False))}
@@ -2336,15 +2423,15 @@ def test_reference_path_into_enum_tuple_as_hard_constraint():
         )
     )
     # T[1] = False always → hard constraint is always False → no solutions.
-    constraint = Reference("T", (1,))
+    constraint = ref("T", (1,))
     assignments = _sat_search(node, constraint)
     assert assignments == [], f"Expected no solutions, got {assignments}"
 
 
 def test_eval_reference_path_uses_zero_based_tuple_indices():
-    expr = Reference("T", (0,))
+    expr = ref("T", (0,))
     assert eval_expression(expr, {"T": (11, 22)}) == 11
-    expr_second = Reference("T", (1,))
+    expr_second = ref("T", (1,))
     assert eval_expression(expr_second, {"T": (11, 22)}) == 22
 
 
@@ -2401,7 +2488,7 @@ def test_sat_search_arbitrary_matches_full_enumeration_plus_apply_methods():
         )
     )
     # Constraint: X == (Y > 1), i.e. X iff Y > 1
-    constraint = Eq(Reference("X", ()), Gt(Reference("Y", ()), IntegerConstant(1)))
+    constraint = Eq(ref("X"), Gt(ref("Y"), IntegerConstant(1)))
 
     label_order = list(labels_in_order(node))
 

--- a/tests/test_interesting.py
+++ b/tests/test_interesting.py
@@ -12,8 +12,8 @@ from equivalib.core import (
     Le,
     Mul,
     Name,
-    Reference,
     Regex,
+    reference,
     generate,
 )
 from equivalib.core.expression import Expression
@@ -28,9 +28,9 @@ class TicketCode(Regex):
 
 def generate_pythagorean_triples(limit: int) -> set[tuple[int, int, int]]:
     tree = cast(type[tuple[int, int, int]], Annotated[tuple[int, int, int], Name("T")])
-    a = Reference("T", (0,))
-    b = Reference("T", (1,))
-    c = Reference("T", (2,))
+    a = reference("T", 0)
+    b = reference("T", 1)
+    c = reference("T", 2)
 
     bounds = And(
         And(Ge(a, IntegerConstant(1)), Le(a, IntegerConstant(limit))),
@@ -50,7 +50,7 @@ def generate_sum_to_hundred_witness() -> set[tuple[int, ...]]:
         type[tuple[int, ...]],
         Annotated[tuple[int, int, int, int, int, int, int, int, int, int], Name("X")],
     )
-    refs = [Reference("X", (i,)) for i in range(10)]
+    refs = [reference("X", i) for i in range(10)]
 
     bounded: And | None = None
     for ref in refs:


### PR DESCRIPTION
### Motivation
- Allow integer leaves to be finitely bounded by numeric constraints that target a leaf by address rather than requiring the leaf to carry a `Name(...)` annotation. 
- Provide a single ergonomic constructor for references that supports both label-based and root-index (unnamed) addressing. 
- Make unnamed-tree generation honor address-based constraints that refer into the root value.

### Description
- Added `reference(first, *rest)` factory and exported it from `equivalib.core`, and updated `Reference` to accept an optional `label: Optional[str]` and normalize `path` to a tuple. (`src/equivalib/core/expression.py`, `src/equivalib/core/__init__.py`)
- Extended validation and expression typing to type-check root-index references (`label=None`) against the root tree shape, and to reject root references when the tree contains `Name(...)` labels. (`src/equivalib/core/validate.py`)
- Reworked integer bounds inference to use reference keys `(label|None, path)` so addressable unbounded integers (including unannotated root-indexed ints) are discovered, inferred, and filled; updated `fill_int_bounds` accordingly. (`src/equivalib/core/bounds_inference.py`, `src/equivalib/core/types.py`)
- Updated unnamed-tree fast path to evaluate the effective constraint per candidate root value using the `{None: value}` assignment so root-index constraints filter unnamed denotations correctly. (`src/equivalib/core/api.py`, `src/equivalib/core/eval.py`)
- Adjusted helpers that collect mentioned labels to ignore `label=None` references and updated caching/collection code accordingly. (`src/equivalib/core/cache.py`)
- Added/updated tests to exercise unannotated address-bounded integers and to use the `reference(...)` factory (new tests in `tests/test_core.py` and updates to `tests/test_interesting.py`). (`tests/test_core.py`, `tests/test_interesting.py`)
- Updated specification text and examples to document optional-label references and address-based integer bounding. (`docs/spec1.md`)

### Testing
- `python -m py_compile` on the modified Python modules and test files passed for the edited modules (expression, validate, eval, cache, bounds_inference, api, and tests). 
- Running selected `pytest` cases was attempted but the test run failed at import time because the environment is missing the `ortools` dependency (`ModuleNotFoundError: No module named 'ortools'`), so full test execution could not be completed here. 
- Changes were committed as a single logical update containing the new reference API, bounds inference adjustments, validation/eval updates, doc edits, and test additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efd0cc5318832e95243c6387a402f5)