### PR TITLE
Expand presentation and migrate tests to use reference()

### DIFF
--- a/docs/presentation.md
+++ b/docs/presentation.md
@@ -3,12 +3,12 @@
 ## Slide 1 — Why this library exists
 
 - Most test failures come from **interactions**, not isolated values.
-- Handwritten fixtures miss combinations.
-- `equivalib` generates concrete cases from declarative models.
+- Handwritten fixtures usually under-sample the real state space.
+- `equivalib` lets you describe **what must hold**, then generates values that satisfy it.
 
 ---
 
-## Slide 2 — Easiest start: one boolean
+## Slide 2 — One-line start: finite booleans
 
 ```python
 from equivalib.core import generate
@@ -17,9 +17,11 @@ values = generate(bool)
 # => {False, True}
 ```
 
+The simplest case is still useful: this is full exhaustive generation for `bool`.
+
 ---
 
-## Slide 3 — Next: a tuple of booleans
+## Slide 3 — Product types: tuple domains
 
 ```python
 from equivalib.core import generate
@@ -33,9 +35,11 @@ values = generate(tuple[bool, bool])
 #    }
 ```
 
+Cartesian products are generated automatically for unnamed tuple trees.
+
 ---
 
-## Slide 4 — Direct indexing on generated values
+## Slide 4 — Post-filtering as a quick triage pattern
 
 ```python
 from equivalib.core import generate
@@ -45,9 +49,29 @@ only_true_first = {item for item in values if item[0]}
 # => {(True, False), (True, True)}
 ```
 
+Great for demos, quick checks, and building intuition.
+
 ---
 
-## Slide 5 — Extension example: finite regex language
+## Slide 5 — In-model constraints via named trees + `reference`
+
+```python
+from typing import Annotated, cast
+from equivalib.core import Eq, Name, generate
+from equivalib.core.expression import reference
+
+tree = cast(type[tuple[bool, bool]], Annotated[tuple[bool, bool], Name("B")])
+constraint = Eq(reference("B", 0), reference("B", 1))
+
+values = generate(tree, constraint, {"B": "all"})
+# => {(False, False), (True, True)}
+```
+
+Instead of filtering after generation, we encode relationships directly into the solver input.
+
+---
+
+## Slide 6 — Extension example: finite regex language
 
 ```python
 from equivalib.core import Regex, generate
@@ -61,35 +85,72 @@ codes = generate(TicketCode)
 # => 200 values: AB00..AB99 and CD00..CD99
 ```
 
+Extensions let domain-specific classes plug into the same generation flow.
+
 ---
 
-## Slide 6 — SAT example: Pythagorean triples in a large integer domain
+## Slide 7 — Realistic data slicing on generated extensions
+
+```python
+codes = generate(TicketCode)
+ab_prefixed = {code for code in codes if str(code).startswith("AB")}
+
+# len(ab_prefixed) == 100
+# TicketCode("AB42") in ab_prefixed
+# TicketCode("CD42") not in ab_prefixed
+```
+
+This pattern keeps generation declarative while still allowing business-level subsets.
+
+---
+
+## Slide 8 — SAT-backed integer relations: Pythagorean triples
 
 ```python
 triples = generate_pythagorean_triples(limit=30)
 # includes (3, 4, 5), (5, 12, 13), (20, 21, 29), ...
 ```
 
-`generate_pythagorean_triples` is implemented with core integer constraints and direct tuple-path indexing (`T[0]`, `T[1]`, `T[2]`) so SAT performs the search.
+`generate_pythagorean_triples` uses integer constraints plus tuple-path references (`reference("T", 0/1/2)`).
 
 ---
 
-## Slide 7 — Large domain, one canonical witness
+## Slide 9 — Canonical witness on huge spaces
 
 ```python
 values = generate_sum_to_hundred_witness()
 # => exactly one tuple witness with sum(value) == 100
 ```
 
-This demonstrates the practical exhaustive-vs-canonical tradeoff on a huge constrained space.
+Using `{"X": "arbitrary"}` asks for one deterministic witness instead of exhaustive enumeration.
 
 ---
 
-## Slide 8 — Takeaway
+## Slide 10 — Practical generation modes
 
-- Start small (`bool` → tuples).
-- Add realistic domains (regex).
-- Use SAT-backed constraints for hard spaces (Pythagorean triples, constrained sums).
-- Keep every example executable in tests.
+- `"all"`: exhaustive values (small/finite spaces).
+- `"arbitrary"`: one canonical satisfying witness.
+- `"uniform_random"`: one random satisfying witness.
+
+Use per-label methods to mix exhaustive and witness-oriented generation.
+
+---
+
+## Slide 11 — Testing strategy in this repository
+
+- Each interesting slide example has a corresponding executable test.
+- Constraints are expressed using AST nodes (`Eq`, `And`, `Add`, ...), not strings.
+- Addressing into named tuples uses `reference("Label", index, ...)`.
+
+This keeps examples both educational and regression-safe.
+
+---
+
+## Slide 12 — Takeaway
+
+- Start small (`bool` and tuples).
+- Move from post-filters to explicit constraints with `reference`.
+- Add domain-specific extensions (regex).
+- Use SAT-backed constraints and witness modes for large integer domains.
 
 All examples above are mirrored in `tests/test_interesting.py`.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -68,8 +68,8 @@ def int_const(value: int) -> Any:
     return core_attr("IntegerConstant")(value)
 
 
-def ref(first: str | int, path: tuple[int, ...] = ()) -> Any:  # noqa: D401
-    return reference(first, *path)
+def ref(first: Union[str, int], *rest: int) -> Any:  # noqa: D401
+    return reference(first, *rest)
 
 
 def _int_bounds(label: str, lo: int, hi: int) -> Any:
@@ -241,7 +241,7 @@ def test_generate_with_address_constraint_on_named_tuple():
     Name = core_attr("Name")
     Ne = core_attr("Ne")
     tree = Annotated[Tuple[bool, bool], Name("X")]
-    constraint = Ne(ref("X", (0,)), ref("X", (1,)))
+    constraint = Ne(ref("X", 0), ref("X", 1))
     assert generate(tree, constraint, {"X": "all"}) == {(True, False), (False, True)}
 
 
@@ -481,8 +481,8 @@ def test_generate_accepts_address_bounded_ints_inside_named_tuple():
     generate = core_attr("generate")
     Name = core_attr("Name")
     tree = Annotated[Tuple[int, int], Name("T")]
-    a = ref("T", (0,))
-    b = ref("T", (1,))
+    a = ref("T", 0)
+    b = ref("T", 1)
     constraint = And(
         And(Ge(a, int_const(1)), Le(a, int_const(2))),
         And(Ge(b, int_const(3)), Le(b, int_const(4))),
@@ -499,9 +499,9 @@ def test_generate_arbitrary_method_works_with_address_bounded_ints():
     generate = core_attr("generate")
     Name = core_attr("Name")
     tree = Annotated[Tuple[int, int, int], Name("T")]
-    x = ref("T", (0,))
-    y = ref("T", (1,))
-    z = ref("T", (2,))
+    x = ref("T", 0)
+    y = ref("T", 1)
+    z = ref("T", 2)
     bounded = And(
         And(Ge(x, int_const(0)), Le(x, int_const(9))),
         And(And(Ge(y, int_const(0)), Le(y, int_const(9))), And(Ge(z, int_const(0)), Le(z, int_const(9)))),
@@ -625,7 +625,7 @@ def test_generate_rejects_invalid_address_on_scalar_label():
     Name = core_attr("Name")
     generate = core_attr("generate")
     with pytest.raises(ValueError):
-        generate(Annotated[bool, Name("X")], Eq(ref("X", (0,)), bool_const(True)), {})
+        generate(Annotated[bool, Name("X")], Eq(ref("X", 0), bool_const(True)), {})
 
 
 def test_generate_rejects_out_of_range_tuple_address():
@@ -633,7 +633,7 @@ def test_generate_rejects_out_of_range_tuple_address():
     Name = core_attr("Name")
     generate = core_attr("generate")
     with pytest.raises(ValueError):
-        generate(Annotated[Tuple[bool], Name("X")], Eq(ref("X", (1,)), bool_const(True)), {})
+        generate(Annotated[Tuple[bool], Name("X")], Eq(ref("X", 1), bool_const(True)), {})
 
 
 def test_generate_rejects_address_that_crosses_shape_boundary():
@@ -642,7 +642,7 @@ def test_generate_rejects_address_that_crosses_shape_boundary():
     generate = core_attr("generate")
     tree = Annotated[Union[Tuple[bool], bool], Name("X")]
     with pytest.raises(ValueError):
-        generate(tree, Eq(ref("X", (0,)), bool_const(True)), {})
+        generate(tree, Eq(ref("X", 0), bool_const(True)), {})
 
 
 def test_generate_rejects_non_boolean_top_level_constraint():
@@ -789,7 +789,7 @@ def test_generate_address_on_union_of_same_arity_tuples():
     Eq = core_attr("Eq")
     # Both branches have arity 1; address (0,) is valid.
     tree = Annotated[Union[Tuple[bool], Tuple[bool]], Name("X")]
-    constraint = Eq(ref("X", (0,)), bool_const(True))
+    constraint = Eq(ref("X", 0), bool_const(True))
     result = generate(tree, constraint, {"X": "all"})
     assert result == {(True,)}
 
@@ -801,7 +801,7 @@ def test_generate_rejects_address_out_of_range_on_all_union_branches():
     Eq = core_attr("Eq")
     tree = Annotated[Union[Tuple[bool], Tuple[bool]], Name("X")]
     with pytest.raises(ValueError):
-        generate(tree, Eq(ref("X", (1,)), bool_const(True)), {})
+        generate(tree, Eq(ref("X", 1), bool_const(True)), {})
 
 
 def test_generate_rejects_negative_tuple_index():
@@ -811,7 +811,7 @@ def test_generate_rejects_negative_tuple_index():
     Eq = core_attr("Eq")
     tree = Annotated[Tuple[bool, bool], Name("X")]
     with pytest.raises(ValueError, match="out of range"):
-        generate(tree, Eq(ref("X", (-1,)), bool_const(True)), {})
+        generate(tree, Eq(ref("X", -1), bool_const(True)), {})
 
 
 def test_generate_rejects_address_valid_only_in_first_union_branch():
@@ -821,14 +821,14 @@ def test_generate_rejects_address_valid_only_in_first_union_branch():
     Eq = core_attr("Eq")
     tree = Annotated[Union[Tuple[Tuple[bool]], Tuple[bool]], Name("X")]
     with pytest.raises(ValueError):
-        generate(tree, Eq(ref("X", (0, 0)), bool_const(True)), {})
+        generate(tree, Eq(ref("X", 0, 0), bool_const(True)), {})
 
 
 def test_validate_rejects_non_int_path_element():
     """A Reference with a non-int path element (e.g. str) must be rejected."""
     tree_node = NamedNode("X", TupleNode((BoolNode(),)))
     # Python does not enforce type annotations at runtime, so this constructs fine
-    expr = ref("X", ("0",))  # type: ignore[arg-type]
+    expr = ref("X", "0")  # type: ignore[arg-type]
     with pytest.raises(ValueError, match="plain int"):
         validate_expression(expr, tree_node)
 
@@ -836,7 +836,7 @@ def test_validate_rejects_non_int_path_element():
 def test_validate_rejects_bool_path_element():
     """A Reference with a bool path element must be rejected (bool is not a plain int index)."""
     tree_node = NamedNode("X", TupleNode((BoolNode(),)))
-    expr = ref("X", (True,))  # bool is a subclass of int, so this type-checks
+    expr = ref("X", True)  # bool is a subclass of int, so this type-checks
     with pytest.raises(ValueError, match="plain int"):
         validate_expression(expr, tree_node)
 
@@ -851,7 +851,7 @@ def test_generate_rejects_path_when_repeated_label_has_non_tuple_occurrence():
         Annotated[bool, Name("X")],
     ]
     with pytest.raises(ValueError):
-        generate(tree, Eq(ref("X", (0,)), bool_const(True)), {})
+        generate(tree, Eq(ref("X", 0), bool_const(True)), {})
 
 
 def test_generate_address_on_nested_union_of_tuples():
@@ -862,7 +862,7 @@ def test_generate_address_on_nested_union_of_tuples():
     # normalize() will produce UnionNode([TupleNode([BoolNode]), UnionNode([TupleNode([BoolNode])])])
     # _resolve_shape must handle nested UnionNodes.
     tree = Annotated[Union[Tuple[bool], Union[Tuple[bool]]], Name("X")]
-    constraint = Eq(ref("X", (0,)), bool_const(True))
+    constraint = Eq(ref("X", 0), bool_const(True))
     result = generate(tree, constraint, {"X": "all"})
     assert result == {(True,)}
 
@@ -2335,7 +2335,7 @@ def test_floordiv_undefined_divisor_no_duplicate_sat_assignments():
     (B, Y) label assignment, not one per (q, r) combination.
     """
     node = TupleNode((NamedNode("B", BoolNode()), NamedNode("Y", IntRangeNode(0, 1))))
-    constraint = Or(ref("B", ()), Eq(FloorDiv(IntegerConstant(1), ref("Y", ())), IntegerConstant(0)))
+    constraint = Or(ref("B"), Eq(FloorDiv(IntegerConstant(1), ref("Y")), IntegerConstant(0)))
     assignments = _sat_search(node, constraint)
     seen: set[frozenset[tuple[str, object]]] = set()
     for asgn in assignments:
@@ -2350,7 +2350,7 @@ def test_mod_undefined_divisor_no_duplicate_sat_assignments():
     Same as the FloorDiv test but using Mod.
     """
     node = TupleNode((NamedNode("B", BoolNode()), NamedNode("Y", IntRangeNode(0, 1))))
-    constraint = Or(ref("B", ()), Eq(Mod(IntegerConstant(1), ref("Y", ())), IntegerConstant(0)))
+    constraint = Or(ref("B"), Eq(Mod(IntegerConstant(1), ref("Y")), IntegerConstant(0)))
     assignments = _sat_search(node, constraint)
     seen: set[frozenset[tuple[str, object]]] = set()
     for asgn in assignments:
@@ -2365,7 +2365,7 @@ def test_mod_undefined_divisor_no_duplicate_sat_assignments():
 
 
 def test_reference_path_into_enum_tuple_in_reify_constraint():
-    """Or(ref("B"), ref("T", (0,))) must follow path when T is an enum label.
+    """Or(ref("B"), ref("T", 0)) must follow path when T is an enum label.
 
     T is a tuple-valued enum label always assigned (True, False).  T[0] = True,
     so Or(B, T[0]) is trivially satisfied for both B=True and B=False.  Before
@@ -2380,7 +2380,7 @@ def test_reference_path_into_enum_tuple_in_reify_constraint():
         )
     )
     # T is always (True, False); T[0]=True, so Or(B, True) must admit B=False too.
-    constraint = Or(ref("B", ()), ref("T", (0,)))
+    constraint = Or(ref("B"), ref("T", 0))
     assignments = _sat_search(node, constraint)
     pairs = {(a["B"], a["T"]) for a in assignments}
     expected = {(True, (True, False)), (False, (True, False))}
@@ -2388,7 +2388,7 @@ def test_reference_path_into_enum_tuple_in_reify_constraint():
 
 
 def test_reference_path_into_enum_tuple_as_hard_constraint():
-    """ref("T", (1,)) as hard constraint must be unsatisfiable when T[1] is always False.
+    """ref("T", 1) as hard constraint must be unsatisfiable when T[1] is always False.
 
     T is always (True, False) so T[1] = False.  Using it as a hard constraint
     must make the model unsatisfiable.  Without the path fix, _add_constraint
@@ -2402,15 +2402,15 @@ def test_reference_path_into_enum_tuple_as_hard_constraint():
         )
     )
     # T[1] = False always → hard constraint is always False → no solutions.
-    constraint = ref("T", (1,))
+    constraint = ref("T", 1)
     assignments = _sat_search(node, constraint)
     assert assignments == [], f"Expected no solutions, got {assignments}"
 
 
 def test_eval_reference_path_uses_zero_based_tuple_indices():
-    expr = ref("T", (0,))
+    expr = ref("T", 0)
     assert eval_expression(expr, {"T": (11, 22)}) == 11
-    expr_second = ref("T", (1,))
+    expr_second = ref("T", 1)
     assert eval_expression(expr_second, {"T": (11, 22)}) == 22
 
 
@@ -2467,7 +2467,7 @@ def test_sat_search_arbitrary_matches_full_enumeration_plus_apply_methods():
         )
     )
     # Constraint: X == (Y > 1), i.e. X iff Y > 1
-    constraint = Eq(ref("X", ()), Gt(ref("Y", ()), IntegerConstant(1)))
+    constraint = Eq(ref("X"), Gt(ref("Y"), IntegerConstant(1)))
 
     label_order = list(labels_in_order(node))
 

--- a/tests/test_core_extensions.py
+++ b/tests/test_core_extensions.py
@@ -24,8 +24,8 @@ def int_const(value: int) -> Any:
     return core_attr("IntegerConstant")(value)
 
 
-def ref(label: str, path: tuple[int, ...] = ()) -> Any:  # noqa: D401
-    return core_attr("Reference")(label, path)
+def ref(first: str | int, *rest: int) -> Any:  # noqa: D401
+    return core_attr("reference")(first, *rest)
 
 
 def _int_bounds(label: str, lo: int, hi: int) -> Any:
@@ -191,7 +191,7 @@ def test_custom_class_address_from_name_and_tuple_path():
 def test_custom_class_leaf_remains_atomic_for_subpaths():
     tree = Annotated[Palette, CoreName("P")]
     with pytest.raises((TypeError, ValueError), match="path|atomic|address"):
-        generate_core(tree, Eq(ref("P", (0,)), ref("P")))
+        generate_core(tree, Eq(ref("P", 0), ref("P")))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_interesting.py
+++ b/tests/test_interesting.py
@@ -12,11 +12,10 @@ from equivalib.core import (
     Le,
     Mul,
     Name,
-    Reference,
     Regex,
     generate,
 )
-from equivalib.core.expression import Expression
+from equivalib.core.expression import Expression, reference
 
 
 
@@ -28,9 +27,9 @@ class TicketCode(Regex):
 
 def generate_pythagorean_triples(limit: int) -> set[tuple[int, int, int]]:
     tree = cast(type[tuple[int, int, int]], Annotated[tuple[int, int, int], Name("T")])
-    a = Reference("T", (0,))
-    b = Reference("T", (1,))
-    c = Reference("T", (2,))
+    a = reference("T", 0)
+    b = reference("T", 1)
+    c = reference("T", 2)
 
     bounds = And(
         And(Ge(a, IntegerConstant(1)), Le(a, IntegerConstant(limit))),
@@ -50,7 +49,7 @@ def generate_sum_to_hundred_witness() -> set[tuple[int, ...]]:
         type[tuple[int, ...]],
         Annotated[tuple[int, int, int, int, int, int, int, int, int, int], Name("X")],
     )
-    refs = [Reference("X", (i,)) for i in range(10)]
+    refs = [reference("X", i) for i in range(10)]
 
     bounded: And | None = None
     for ref in refs:
@@ -85,12 +84,30 @@ def test_interesting_direct_indexing_on_generated_tuple_values():
     assert only_true_first == {(True, False), (True, True)}
 
 
+def test_interesting_tuple_constraint_with_reference_paths():
+    tree = cast(type[tuple[bool, bool]], Annotated[tuple[bool, bool], Name("B")])
+    same_value = Eq(reference("B", 0), reference("B", 1))
+
+    values = generate(tree, same_value, {"B": "all"})
+
+    assert values == {(False, False), (True, True)}
+
+
 def test_interesting_ticket_code_regex_language():
     values = generate(TicketCode)
 
     assert len(values) == 200
     assert TicketCode("AB00") in values
     assert TicketCode("CD99") in values
+
+
+def test_interesting_ticket_code_prefix_filtering_example():
+    values = generate(TicketCode)
+    ab_prefixed = {code for code in values if str(code).startswith("AB")}
+
+    assert len(ab_prefixed) == 100
+    assert TicketCode("AB42") in ab_prefixed
+    assert TicketCode("CD42") not in ab_prefixed
 
 
 def test_interesting_pythagorean_triples_are_found_via_sat_constraints():


### PR DESCRIPTION
### Motivation
- Make the presentation examples more informative and runnable by expanding the short draft into a fuller slide deck with clearer, executable examples.
- Move tests away from constructing AST references via the `Reference` class to the `reference()` function to keep a single, stable API for creating addressable references.
- Align helper signatures and callsites so test helpers mirror the `reference` function signature and accept variadic path indices.

### Description
- Expanded `docs/presentation.md` from a brief 8-slide draft into a 12-slide narrative with additional examples, descriptions of generation modes, and a concrete example showing in-model constraints using `reference("Label", index, ...)`.
- Replaced all direct `Reference(...)` constructor usage in tests with `reference(...)` and updated imports accordingly (notably in `tests/test_interesting.py` and `tests/test_core_extensions.py`).
- Changed the test helper `ref` signatures to `ref(first: Union[str, int], *rest: int)` and updated call sites from tuple-path style (e.g. `(0,)`) to variadic index arguments (e.g. `0`, `0, 1`) across `tests/test_core.py` and `tests/test_core_extensions.py`.
- Added two improved examples/tests in `tests/test_interesting.py`: a named-tuple equality constraint using `reference(...)` and a regex-prefix slicing example for `TicketCode` values.

### Testing
- Ran `python -m compileall -q tests/test_core.py tests/test_core_extensions.py tests/test_interesting.py docs/presentation.md` which succeeded for syntax/compilation checks.
- Attempted `pytest -q tests/test_interesting.py tests/test_core_extensions.py tests/test_core.py`, but collection failed with `ModuleNotFoundError: No module named 'ortools'` in this environment, so full test execution could not complete.
- No remaining tests create `Reference` instances directly; tests now use `reference()` / updated `ref(...)` helpers (observed by static edits and compilation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efe4028e74832eb5e3b97ff315897a)